### PR TITLE
Add Rollershutter Accessory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Here's a list of the devices that are currently exposed:
 * **Switches** - on/off
 * **Scenes** - exposed as an on/off switch
 * **Media Players** - exposed as an on/off switch
+* **Rollershutter** - exposed as a garage door
 
 ### Scene Support
 
@@ -63,7 +64,7 @@ adding it to your `config.json`.
     "name": "HomeAssistant",
     "host": "http://192.168.1.16:8123",
     "password": "yourapipassword",
-    "supported_types": ["light", "switch", "media_player", "scene"]
+    "supported_types": ["light", "switch", "media_player", "scene", "rollershutter"]
   }
 ]
 ```

--- a/accessories/rollershutter.js
+++ b/accessories/rollershutter.js
@@ -1,0 +1,102 @@
+var Service, Characteristic, communicationError;
+
+module.exports = function (oService, oCharacteristic, oCommunicationError) {
+  Service = oService;
+  Characteristic = oCharacteristic;
+  communicationError = oCommunicationError;
+
+  return HomeAssistantRollershutter;
+};
+module.exports.HomeAssistantRollershutter = HomeAssistantRollershutter;
+
+function HomeAssistantRollershutter(log, data, client) {
+  // device info
+  this.domain = "rollershutter"
+  this.data = data
+  this.entity_id = data.entity_id
+  if (data.attributes && data.attributes.friendly_name) {
+    this.name = data.attributes.friendly_name
+  }else{
+    this.name = data.entity_id.split('.').pop().replace(/_/g, ' ')
+  }
+
+  this.client = client
+  this.log = log;
+}
+
+HomeAssistantRollershutter.prototype = {
+  getOpenState: function(callback){
+    this.client.fetchState(this.entity_id, function(data){
+      if (data && data.attributes) {
+
+        // if rollershutter state == 'open' then the door is closed ie you can't walk through it
+        // rollershutter "closed" means the rollershutter itself is closed (rolled up), so the door is open
+        // see discussion at https://github.com/home-assistant/home-assistant-polymer/pull/54
+
+        // HomeKit door states: 0 is open, 1 is closed
+        // https://github.com/KhaosT/HAP-NodeJS/blob/621d188bc9799c631d763c75aafdd7f4a7ee8ba3/lib/gen/HomeKitTypes.js#L443
+        if (data.attributes.current_position == 100) {
+            // Rollershutter is fully unrolled / doorway or window is closed
+            openState = 1
+        } else {
+            // Consider doorway open if rollershutter is not fully open
+            openState = 0
+        }
+        callback(null, openState)
+      }else{
+        callback(communicationError)
+      }
+    }.bind(this))
+  },
+  setOpenState: function(rollershutterCommand, callback) {
+    var that = this;
+    var service_data = {}
+    service_data.entity_id = this.entity_id
+
+    // Open is 0 / false
+    if (!rollershutterCommand) {
+      this.log("Setting the state of the '"+this.name+"' to open");
+
+      this.client.callService(this.domain, 'move_up', service_data, function(data){
+        if (data) {
+          that.log("Successfully set state of '"+that.name+"' to open");
+          callback()
+        }else{
+          callback(communicationError)
+        }
+      }.bind(this))
+    }else{
+      this.log("Setting the state of the '"+this.name+"' to closed");
+
+      this.client.callService(this.domain, 'move_down', service_data, function(data){
+        if (data) {
+          that.log("Successfully set state of '"+that.name+"' to closed");
+          callback()
+        }else{
+          callback(communicationError)
+        }
+      }.bind(this))
+    }
+  },
+  getServices: function() {
+    var rollershutterService = new Service.GarageDoorOpener();
+    var informationService = new Service.AccessoryInformation();
+    var model;
+
+    informationService
+      .setCharacteristic(Characteristic.Manufacturer, "Home Assistant")
+      .setCharacteristic(Characteristic.Model, "Rollershutter")
+      .setCharacteristic(Characteristic.SerialNumber, "xxx");
+
+    rollershutterService
+      .getCharacteristic(Characteristic.CurrentDoorState)
+      .on('get', this.getOpenState.bind(this));
+
+    rollershutterService
+      .getCharacteristic(Characteristic.TargetDoorState)
+      .on('get', this.getOpenState.bind(this))
+      .on('set', this.setOpenState.bind(this));
+
+    return [informationService, rollershutterService];
+  }
+}

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var communicationError = new Error('Can not communicate with Home Assistant.')
 
 var HomeAssistantLight;
 var HomeAssistantSwitch;
+var HomeAssistantRollershutter;
 var HomeAssistantMediaPlayer;
 
 
@@ -18,6 +19,7 @@ module.exports = function(homebridge) {
 
   HomeAssistantLight = require('./accessories/light')(Service, Characteristic, communicationError);
   HomeAssistantSwitch = require('./accessories/switch')(Service, Characteristic, communicationError);
+  HomeAssistantRollershutter = require('./accessories/rollershutter')(Service, Characteristic, communicationError);
   HomeAssistantMediaPlayer = require('./accessories/media_player')(Service, Characteristic, communicationError);
 
   homebridge.registerPlatform("homebridge-homeassistant", "HomeAssistant", HomeAssistantPlatform, false);
@@ -132,6 +134,8 @@ HomeAssistantPlatform.prototype = {
           accessory = new HomeAssistantLight(that.log, entity, that)
         }else if (entity_type == 'switch'){
           accessory = new HomeAssistantSwitch(that.log, entity, that)
+        }else if (entity_type == 'rollershutter'){
+          accessory = new HomeAssistantRollershutter(that.log, entity, that)
         }else if (entity_type == 'scene'){
           accessory = new HomeAssistantSwitch(that.log, entity, that, 'scene')
         }else if (entity_type == 'media_player' && entity.attributes && entity.attributes.supported_media_commands){


### PR DESCRIPTION
This PR adds a [Home Assistant rollershutter](https://home-assistant.io/components/rollershutter/) as a supported accessory type using the GarageDoorOpener Service.

With my command line rollershutter at home it's working well:

- reads the state (open or closed) to match the current Home Assistant state
- sets the target state button to match the current state
- target state button changes the target state and appropriately opens or closes the rollershutter

Previously, Siri would refuse to interact with switches named e.g. "garage," because ostensibly it was looking for a GarageDoorOpener type. Now Siri is happy to "open the garage," if that's what your device is named.