### PR TITLE
Retry connecting to HA API

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,11 @@ HomeAssistantPlatform.prototype = {
     var foundAccessories = [];
 
     this._request('GET', '/states', {}, function(error, response, data){
-      that.log(error)
+      if (error) {
+        that.log("Failed getting devices: " + error + ". Retrying...");
+        setTimeout(function() { that.accessories(callback); }, 5000);
+        return;
+      }
       // that.log(response)
       that.log(data)
 


### PR DESCRIPTION
This is useful when the system first boots and HA server isn't ready for
answering requests by the time HomeBrigde is started. This way it will retry
instead of crashing HomeBridge altogether.