### PR TITLE
Disregard old_state in SSE (Closes #32)

### DIFF
--- a/accessories/garage_door.js
+++ b/accessories/garage_door.js
@@ -26,9 +26,6 @@ function HomeAssistantGarageDoor(log, data, client, type) {
 
 HomeAssistantGarageDoor.prototype = {
   onEvent: function(old_state, new_state) {
-    if (old_state.state == new_state.state)
-      return;
-
     var garageState = new_state.state == 'open' ? 0 : 1;
     this.garageService.getCharacteristic(Characteristic.CurrentDoorState)
         .setValue(garageState, null, 'internal');

--- a/accessories/light.js
+++ b/accessories/light.js
@@ -40,12 +40,9 @@ HomeAssistantLight.prototype = {
       ((this.data.attributes.supported_features & feature) > 0)
   },
   onEvent: function(old_state, new_state) {
-    if (old_state.state != new_state.state) {
-      this.lightbulbService.getCharacteristic(Characteristic.On)
-        .setValue(new_state.state == 'on', null, 'internal');
-    }
-    if (this.is_supported(this.features.BRIGHTNESS) &&
-      old_state.attributes.brightness != new_state.attributes.brightness) {
+    this.lightbulbService.getCharacteristic(Characteristic.On)
+      .setValue(new_state.state == 'on', null, 'internal');
+    if (this.is_supported(this.features.BRIGHTNESS)) {
       var brightness = Math.round(((new_state.attributes.brightness || 0) / 255) * 100);
       this.lightbulbService.getCharacteristic(Characteristic.Brightness)
         .setValue(brightness, null, 'internal');

--- a/accessories/lock.js
+++ b/accessories/lock.js
@@ -26,9 +26,6 @@ function HomeAssistantLock(log, data, client, type) {
 
 HomeAssistantLock.prototype = {
   onEvent: function(old_state, new_state) {
-    if (old_state.state == new_state.state)
-      return;
-
     var lockState = new_state.state == 'unlocked' ? 0 : 1;
     this.lockService.getCharacteristic(Characteristic.LockCurrentState)
       .setValue(lockState, null, 'internal');

--- a/accessories/media_player.js
+++ b/accessories/media_player.js
@@ -56,9 +56,6 @@ function HomeAssistantMediaPlayer(log, data, client) {
 
 HomeAssistantMediaPlayer.prototype = {
   onEvent: function(old_state, new_state) {
-    if (old_state.state == new_state.state)
-      return;
-
     this.switchService.getCharacteristic(Characteristic.On)
       .setValue(new_state.state == this.onState, null, 'internal');
   },

--- a/accessories/rollershutter.js
+++ b/accessories/rollershutter.js
@@ -26,9 +26,6 @@ function HomeAssistantRollershutter(log, data, client) {
 
 HomeAssistantRollershutter.prototype = {
   onEvent: function(old_state, new_state) {
-    if (old_state.attributes.current_position == new_state.attributes.current_position)
-      return;
-
     /* See getOpenState() for details on these values */
     var state = new_state.attributes.current_position == 100 ? 1 : 0;
     this.rollershutterService.getCharacteristic(Characteristic.CurrentDoorState)

--- a/accessories/switch.js
+++ b/accessories/switch.js
@@ -26,9 +26,6 @@ function HomeAssistantSwitch(log, data, client, type) {
 
 HomeAssistantSwitch.prototype = {
   onEvent: function(old_state, new_state) {
-    if (old_state.state == new_state.state)
-      return;
-
     this.switchService.getCharacteristic(Characteristic.On)
       .setValue(new_state.state == 'on', null, 'internal');
   },


### PR DESCRIPTION
In some cases old_state may be null which means we first have to make sure it
exists before comparing to the new state. However, this added complexity is
probably not worth looking at the old state at all and simply reflect the new
state as is.