### PR TITLE
Add uuid_base to all accessories

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Here's a list of the devices that are currently exposed:
 * **Fan** - on/off/speed
 * **Input boolean** - on/off
 * **Sensors** - temperature, light and humidity sensors
+* **Binary Sensor** - door, leak, moisture, motion, smoke, and window state
 
 ### Scene Support
 
@@ -69,7 +70,7 @@ adding it to your `config.json`.
     "name": "HomeAssistant",
     "host": "http://192.168.1.16:8123",
     "password": "yourapipassword",
-    "supported_types": ["fan", "garage_door", "input_boolean", "light", "lock", "media_player", "rollershutter", "scene", "sensor", "switch"]
+    "supported_types": ["binary_sensor", "fan", "garage_door", "input_boolean", "light", "lock", "media_player", "rollershutter", "scene", "sensor", "switch"]
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Here's a list of the devices that are currently exposed:
 * **Rollershutter** - exposed as a garage door
 * **Fan** - on/off/speed
 * **Input boolean** - on/off
+* **Sensors** - temperature, light and humidity sensors
 
 ### Scene Support
 
@@ -68,7 +69,7 @@ adding it to your `config.json`.
     "name": "HomeAssistant",
     "host": "http://192.168.1.16:8123",
     "password": "yourapipassword",
-    "supported_types": ["fan", "garage_door", "input_boolean", "light", "lock", "media_player", "rollershutter", "scene", "switch"]
+    "supported_types": ["fan", "garage_door", "input_boolean", "light", "lock", "media_player", "rollershutter", "scene", "sensor", "switch"]
   }
 ]
 ```

--- a/accessories/binary_sensor.js
+++ b/accessories/binary_sensor.js
@@ -1,0 +1,138 @@
+var Service, Characteristic, communicationError;
+
+module.exports = function (oService, oCharacteristic, oCommunicationError) {
+  Service = oService;
+  Characteristic = oCharacteristic;
+  communicationError = oCommunicationError;
+
+  return HomeAssistantBinarySensorFactory;
+};
+module.exports.HomeAssistantBinarySensorFactory = HomeAssistantBinarySensorFactory;
+
+function HomeAssistantBinarySensorFactory(log, data, client) {
+  if (!(data.attributes && data.attributes.sensor_class)) {
+    return null;
+  }
+  switch(data.attributes.sensor_class) {
+    case 'moisture':
+      return new HomeAssistantBinarySensor(log, data, client,
+          Service.LeakSensor,
+          Characteristic.LeakDetected,
+          Characteristic.LeakDetected.LEAK_DETECTED,
+          Characteristic.LeakDetected.LEAK_NOT_DETECTED);
+    case 'motion':
+      return new HomeAssistantBinarySensor(log, data, client,
+          Service.MotionSensor,
+          Characteristic.MotionDetected,
+          true,
+          false);
+    case 'occupancy':
+      return new HomeAssistantBinarySensor(log, data, client,
+          Service.OccupancySensor,
+          Characteristic.OccupancyDetected,
+          Characteristic.OccupancyDetected.OCCUPANCY_DETECTED,
+          Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED);
+    case 'opening':
+      return new HomeAssistantOpening(log, data, client);
+    case 'smoke':
+      return new HomeAssistantBinarySensor(log, data, client,
+          Service.SmokeSensor,
+          Characteristic.SmokeDetected,
+          Characteristic.SmokeDetected.SMOKE_DETECTED,
+          Characteristic.SmokeDetected.SMOKE_NOT_DETECTED);
+    default:
+      return null;
+  }
+}
+
+class HomeAssistantBinarySensor {
+  constructor(log, data, client, service, characteristic, onValue, offValue) {
+    // device info
+    this.data = data;
+    this.entity_id = data.entity_id;
+    if (data.attributes && data.attributes.friendly_name) {
+      this.name = data.attributes.friendly_name;
+    } else {
+      this.name = data.entity_id.split('.').pop().replace(/_/g, ' ');
+    }
+  
+    this.entity_type = data.entity_id.split('.')[0];
+  
+    this.client = client;
+    this.log = log;
+
+    this.service = service;
+    this.characteristic = characteristic;
+    this.onValue = onValue;
+    this.offValue = offValue;
+  }
+
+  onEvent(old_state, new_state) {
+    this.sensorService.getCharacteristic(this.characteristic)
+      .setValue(new_state.state == "on" ? this.onValue : this.offValue, null, 'internal');
+  }
+  identify(callback) {
+    this.log("identifying: " + this.name);
+    callback();
+  }
+  getState(callback) {
+    this.log("fetching state for: " + this.name);
+    this.client.fetchState(this.entity_id, function(data){
+      if (data) {
+        callback(null, data.state == "on" ? this.onValue : this.offValue);
+      } else {
+        callback(communicationError);
+      } 
+    }.bind(this));
+  }
+  getServices() {
+    this.sensorService = new this.service();
+    this.sensorService
+      .getCharacteristic(this.characteristic)
+      .on('get', this.getState.bind(this));
+    var informationService = new Service.AccessoryInformation();
+
+    informationService
+      .setCharacteristic(Characteristic.Manufacturer, "Home Assistant")
+      .setCharacteristic(Characteristic.Model, "Binary Sensor")
+      .setCharacteristic(Characteristic.SerialNumber, "xxx");
+
+    return [informationService, this.sensorService];
+  }
+}
+
+class HomeAssistantOpening extends HomeAssistantBinarySensor {
+  constructor(log, data, client) {
+    super(log, data, client);
+    if (data.attributes.homebridge_opening_type && data.attributes.homebridge_opening_type == 'window') {
+      this.service = Service.Window;
+    } else {
+      this.service = Service.Door;
+    }
+    this.characteristic = Characteristic.CurrentPosition;
+    this.onValue = 100;
+    this.offValue = 0;
+  }
+  onEvent(old_state, new_state) {
+    super.onEvent(old_state, new_state);
+    this.sensorService.getCharacteristic(Characteristic.TargetPosition)
+      .setValue(new_state == "on" ? this.onValue : this.offValue);
+    this.sensorService.getCharacteristic(Characteristic.PositionState)
+      .setValue(Characteristic.PositionState.STOPPED);
+  }
+  getPositionState(callback) {
+    callback(null, Characteristic.PositionState.STOPPED);
+  }
+  getServices() {
+    var services = super.getServices();
+    this.sensorService
+      .getCharacteristic(Characteristic.PositionState)
+      .on('get', this.getPositionState.bind(this));
+
+    this.sensorService
+      .getCharacteristic(Characteristic.TargetPosition)
+      .on('get', this.getState.bind(this));
+
+    return services;
+  }
+}

--- a/accessories/binary_sensor.js
+++ b/accessories/binary_sensor.js
@@ -50,6 +50,7 @@ class HomeAssistantBinarySensor {
     // device info
     this.data = data;
     this.entity_id = data.entity_id;
+    this.uuid_base = data.entity_id;
     if (data.attributes && data.attributes.friendly_name) {
       this.name = data.attributes.friendly_name;
     } else {

--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -14,6 +14,7 @@ function HomeAssistantFan(log, data, client) {
   this.domain = "fan"
   this.data = data
   this.entity_id = data.entity_id
+  this.uuid_base = data.entity_id
   if (data.attributes && data.attributes.friendly_name) {
     this.name = data.attributes.friendly_name
   }else{

--- a/accessories/garage_door.js
+++ b/accessories/garage_door.js
@@ -14,6 +14,7 @@ function HomeAssistantGarageDoor(log, data, client, type) {
   this.domain = "garage_door"
   this.data = data
   this.entity_id = data.entity_id
+  this.uuid_base = data.entity_id
   if (data.attributes && data.attributes.friendly_name) {
     this.name = data.attributes.friendly_name
   }else{

--- a/accessories/light.js
+++ b/accessories/light.js
@@ -14,6 +14,7 @@ function HomeAssistantLight(log, data, client) {
   this.domain = "light"
   this.data = data
   this.entity_id = data.entity_id
+  this.uuid_base = data.entity_id
   if (data.attributes && data.attributes.friendly_name) {
     this.name = data.attributes.friendly_name
   }else{

--- a/accessories/lock.js
+++ b/accessories/lock.js
@@ -14,6 +14,7 @@ function HomeAssistantLock(log, data, client, type) {
   this.domain = "lock"
   this.data = data
   this.entity_id = data.entity_id
+  this.uuid_base = data.entity_id
   if (data.attributes && data.attributes.friendly_name) {
     this.name = data.attributes.friendly_name
   }else{

--- a/accessories/media_player.js
+++ b/accessories/media_player.js
@@ -25,6 +25,7 @@ function HomeAssistantMediaPlayer(log, data, client) {
   this.domain = "media_player"
   this.data = data
   this.entity_id = data.entity_id
+  this.uuid_base = data.entity_id
   this.supportedMediaCommands = data.attributes.supported_media_commands
 
   if (data.attributes && data.attributes.friendly_name) {

--- a/accessories/rollershutter.js
+++ b/accessories/rollershutter.js
@@ -14,6 +14,7 @@ function HomeAssistantRollershutter(log, data, client) {
   this.domain = "rollershutter"
   this.data = data
   this.entity_id = data.entity_id
+  this.uuid_base = data.entity_id
   if (data.attributes && data.attributes.friendly_name) {
     this.name = data.attributes.friendly_name
   }else{

--- a/accessories/sensor.js
+++ b/accessories/sensor.js
@@ -1,0 +1,108 @@
+var Service, Characteristic, communicationError;
+
+module.exports = function (oService, oCharacteristic, oCommunicationError) {
+  Service = oService;
+  Characteristic = oCharacteristic;
+  communicationError = oCommunicationError;
+
+  return HomeAssistantSensorFactory;
+};
+
+function HomeAssistantSensorFactory(log, data, client) {
+  if (!data.attributes) {
+    return null;
+  }
+  var service, characteristic, transformData;
+  if (data.attributes.unit_of_measurement === '°C' || data.attributes.unit_of_measurement === '°F') {
+    service = Service.TemperatureSensor;
+    characteristic = Characteristic.CurrentTemperature;
+    transformData = function(data) {
+      var value = parseFloat(data.state);
+      // HomeKit only works with Celsius internally
+      if (data.attributes.unit_of_measurement === '°F') {
+        value = (value - 32) / 1.8;
+      }
+      return value;
+    };
+  } else if (data.attributes.unit_of_measurement === "%" && data.entity_id.includes("humidity")) {
+    service = Service.HumiditySensor;
+    characteristic = Characteristic.CurrentRelativeHumidity;
+  } else if (data.attributes.unit_of_measurement === "lux") {
+    service = Service.LightSensor;
+    characteristic = Characteristic.CurrentAmbientLightLevel;
+    transformData = function(data) {
+      return Math.max(0.0001, parseFloat(data.state));
+    };
+  } else {
+    return null;
+  }
+
+  return new HomeAssistantSensor(log, data, client, service, characteristic, transformData);
+}
+
+class HomeAssistantSensor {
+  constructor(log, data, client, service, characteristic, transformData) {
+    // device info
+    this.data = data;
+    this.entity_id = data.entity_id;
+    if (data.attributes && data.attributes.friendly_name) {
+      this.name = data.attributes.friendly_name;
+    }else{
+      this.name = data.entity_id.split('.').pop().replace(/_/g, ' ');
+    }
+  
+    this.entity_type = data.entity_id.split('.')[0];
+  
+    this.client = client;
+    this.log = log;
+
+    this.service = service;
+    this.characteristic = characteristic;
+    if (transformData) {
+      this.transformData = transformData;
+    }
+  }
+
+  transformData(data) {
+    return parseFloat(data.state);
+  }
+
+  onEvent(old_state, new_state) {
+    this.sensorService.getCharacteristic(this.characteristic)
+      .setValue(this.transformData(new_state), null, 'internal');
+  }
+
+  identify(callback){
+    this.log("identifying: " + this.name);
+    callback();
+  }
+
+  getState(callback){
+    this.log("fetching state for: " + this.name);
+    this.client.fetchState(this.entity_id, function(data) {
+      if (data) {
+        callback(null, this.transformData(data));
+      }else{
+        callback(communicationError);
+      } 
+    }.bind(this));
+  }
+
+  getServices() {
+    this.sensorService = new this.service();
+    var informationService = new Service.AccessoryInformation();
+
+    informationService
+      .setCharacteristic(Characteristic.Manufacturer, "Home Assistant")
+      .setCharacteristic(Characteristic.Model, "Sensor")
+      .setCharacteristic(Characteristic.SerialNumber, "xxx");
+
+    this.sensorService
+      .getCharacteristic(this.characteristic)
+      .on('get', this.getState.bind(this));
+
+    return [informationService, this.sensorService];
+  }
+}
+
+module.exports.HomeAssistantSensorFactory = HomeAssistantSensorFactory;

--- a/accessories/sensor.js
+++ b/accessories/sensor.js
@@ -45,6 +45,7 @@ class HomeAssistantSensor {
     // device info
     this.data = data;
     this.entity_id = data.entity_id;
+    this.uuid_base = data.entity_id;
     if (data.attributes && data.attributes.friendly_name) {
       this.name = data.attributes.friendly_name;
     }else{

--- a/accessories/switch.js
+++ b/accessories/switch.js
@@ -14,6 +14,7 @@ function HomeAssistantSwitch(log, data, client, type) {
   this.domain = type || "switch"
   this.data = data
   this.entity_id = data.entity_id
+  this.uuid_base = data.entity_id
   if (data.attributes && data.attributes.friendly_name) {
     this.name = data.attributes.friendly_name
   }else{

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var HomeAssistantMediaPlayer;
 var HomeAssistantRollershutter;
 var HomeAssistantFan;
 var HomeAssistantSensorFactory;
+var HomeAssistantBinarySensorFactory;
 
 module.exports = function(homebridge) {
   console.log("homebridge API version: " + homebridge.version);
@@ -29,6 +30,7 @@ module.exports = function(homebridge) {
   HomeAssistantMediaPlayer = require('./accessories/media_player')(Service, Characteristic, communicationError);
   HomeAssistantFan = require('./accessories/fan')(Service, Characteristic, communicationError);
   HomeAssistantSensorFactory = require('./accessories/sensor')(Service, Characteristic, communicationError);
+  HomeAssistantBinarySensorFactory = require('./accessories/binary_sensor')(Service, Characteristic, communicationError);
 
   homebridge.registerPlatform("homebridge-homeassistant", "HomeAssistant", HomeAssistantPlatform, false);
 }
@@ -188,6 +190,8 @@ HomeAssistantPlatform.prototype = {
           accessory = new HomeAssistantFan(that.log, entity, that)
         }else if (entity_type == 'sensor'){
           accessory = HomeAssistantSensorFactory(that.log, entity, that)
+        }else if (entity_type == 'binary_sensor' && entity.attributes && entity.attributes.sensor_class) {
+          accessory = HomeAssistantBinarySensorFactory(that.log, entity, that)
         }
 
         if (accessory) {

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var HomeAssistantGarageDoor;
 var HomeAssistantMediaPlayer;
 var HomeAssistantRollershutter;
 var HomeAssistantFan;
+var HomeAssistantSensorFactory;
 
 module.exports = function(homebridge) {
   console.log("homebridge API version: " + homebridge.version);
@@ -27,6 +28,7 @@ module.exports = function(homebridge) {
   HomeAssistantRollershutter = require('./accessories/rollershutter')(Service, Characteristic, communicationError);
   HomeAssistantMediaPlayer = require('./accessories/media_player')(Service, Characteristic, communicationError);
   HomeAssistantFan = require('./accessories/fan')(Service, Characteristic, communicationError);
+  HomeAssistantSensorFactory = require('./accessories/sensor')(Service, Characteristic, communicationError);
 
   homebridge.registerPlatform("homebridge-homeassistant", "HomeAssistant", HomeAssistantPlatform, false);
 }
@@ -139,8 +141,6 @@ HomeAssistantPlatform.prototype = {
         setTimeout(function() { that.accessories(callback); }, 5000);
         return;
       }
-      // that.log(response)
-      // that.log(data)
 
       for (var i = 0; i < data.length; i++) {
         entity = data[i]
@@ -186,6 +186,8 @@ HomeAssistantPlatform.prototype = {
           accessory = new HomeAssistantSwitch(that.log, entity, that, 'input_boolean')
         }else if (entity_type == 'fan'){
           accessory = new HomeAssistantFan(that.log, entity, that)
+        }else if (entity_type == 'sensor'){
+          accessory = HomeAssistantSensorFactory(that.log, entity, that)
         }
 
         if (accessory) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "http://github.com/home-assistant/homebridge-homeassistant/issues"
   },
   "engines": {
-    "node": ">=0.12.0",
+    "node": ">=4.3.2",
     "homebridge": ">=0.3.0"
   },
   "dependencies": {


### PR DESCRIPTION
Currently, homebridge uses the accessory type and display name to generate the
UUID. That means that if two devices have the same display name in the house,
we will crash on startup. It also means that renaming a device will have all
of its HomeKit configuration (like which room it is in) lost.

This change will break many peoples' setups - devices will be put in the
default room, and they will need to re-organize them.