### PR TITLE
Cover support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Here's a list of the devices that are currently exposed:
 * **Lock** - lock/unlock lock
 * **Garage Door** - open/close garage door
 * **Rollershutter** - exposed as a garage door
+* **Cover** - exposed as a garage door (see notes)
 * **Fan** - on/off/speed
 * **Input boolean** - on/off
 
@@ -47,6 +48,19 @@ There are some rules to know about how on/off treats your media player. If
 your media player supports play/pause, then turning them on and off via
 HomeKit will play and pause them. If they do not support play/pause but instead
 support on/off they will be turned on and off.
+
+### Cover Support
+
+Covers on your Home Assistant will appear as garage doors, however their real
+type must be specified in the `customize` section of your Home Assistant's
+`configuration.yaml`. Refer to the following example:
+
+```
+cover.lounge_main:
+  homebridge_cover_type: rollershutter
+cover.garage:
+  homebridge_cover_type: garage_door
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ type must be specified in the `customize` section of your Home Assistant's
 `configuration.yaml`. Refer to the following example:
 
 ```
-cover.lounge_main:
-  homebridge_cover_type: rollershutter
-cover.garage:
-  homebridge_cover_type: garage_door
+customize:
+  cover.lounge_main:
+    homebridge_cover_type: rollershutter
+  cover.garage:
+    homebridge_cover_type: garage_door
 ```
 
 ## Installation

--- a/accessories/cover.js
+++ b/accessories/cover.js
@@ -38,9 +38,9 @@ HomeAssistantCover.prototype = {
   onEvent: function(old_state, new_state) {
     var coverState = new_state.attributes.current_position == 100 ? 1 : 0;
     this.coverService.getCharacteristic(Characteristic.CurrentDoorState)
-        .setValue(garageState, null, 'internal');
+        .setValue(coverState, null, 'internal');
     this.coverService.getCharacteristic(Characteristic.TargetDoorState)
-        .setValue(garageState, null, 'internal');
+        .setValue(coverState, null, 'internal');
   },
   getCoverState: function(callback){
     this.client.fetchState(this.entity_id, function(data){

--- a/accessories/cover.js
+++ b/accessories/cover.js
@@ -118,6 +118,9 @@ HomeAssistantCover.prototype = {
     this.model = (this.cover_type === "garage_door") ? "Garage Door" : "Rollershutter";
     this.stateCharacteristic = (this.cover_type === "garage_door") ? Characteristic.CurrentDoorState : Characteristic.TargetDoorState;
     this.targetCharacteristic = (this.cover_type === "garage_door") ? Characteristic.TargetDoorState : Characteristic.TargetPosition;
+    this.stateCharacteristicGetFunction = (this.cover_type === "garage_door") ? this.getCoverState : this.getPosition;
+    this.targetCharacteristicGetFunction = (this.cover_type === "garage_door") ? this.getCoverState : this.getPosition;
+    this.targetCharacteristicSetFunction = (this.cover_type === "garage_door") ? this.setCoverState : this.setPosition;
 
     var informationService = new Service.AccessoryInformation();
     informationService
@@ -127,12 +130,12 @@ HomeAssistantCover.prototype = {
 
     this.coverService
       .getCharacteristic(this.stateCharacteristic)
-      .on("get", this.getPosition.bind(this));
+      .on("get", this.stateCharacteristicGetFunction.bind(this));
 
     this.coverService
       .getCharacteristic(this.targetCharacteristic)
-      .on("get", this.getPosition.bind(this))
-      .on("set", this.setPosition.bind(this));
+      .on("get", this.targetCharacteristicGetFunction.bind(this))
+      .on("set", this.targetCharacteristicSetFunction.bind(this));
 
     return [informationService, this.coverService];
   }

--- a/accessories/cover.js
+++ b/accessories/cover.js
@@ -65,7 +65,7 @@ HomeAssistantCover.prototype = {
     if (coverOn) {
       this.log("Setting cover state on the '"+this.name+"' to closed");
 
-      this.client.callService(this.domain, 'close', service_data, function(data){
+      this.client.callService(this.domain, 'close_cover', service_data, function(data){
         if (data) {
           that.log("Successfully set cover state on the '"+that.name+"' to closed");
           callback()
@@ -76,7 +76,7 @@ HomeAssistantCover.prototype = {
     }else{
       this.log("Setting cover state on the '"+this.name+"' to open");
 
-      this.client.callService(this.domain, 'open', service_data, function(data){
+      this.client.callService(this.domain, 'open_cover', service_data, function(data){
         if (data) {
           that.log("Successfully set cover state on the '"+that.name+"' to open");
           callback()

--- a/accessories/cover.js
+++ b/accessories/cover.js
@@ -36,7 +36,7 @@ function HomeAssistantCover(log, data, client, type) {
 
 HomeAssistantCover.prototype = {
   onEvent: function(old_state, new_state) {
-    var coverState = new_state.attributes.current_position == 100 ? 1 : 0;
+    var coverState = new_state.attributes.current_position == 100 ? 0 : 1;
     this.coverService.getCharacteristic(Characteristic.CurrentDoorState)
         .setValue(coverState, null, 'internal');
     this.coverService.getCharacteristic(Characteristic.TargetDoorState)

--- a/accessories/cover.js
+++ b/accessories/cover.js
@@ -1,0 +1,114 @@
+var Service, Characteristic, communicationError;
+
+module.exports = function (oService, oCharacteristic, oCommunicationError) {
+  Service = oService;
+  Characteristic = oCharacteristic;
+  communicationError = oCommunicationError;
+
+  return HomeAssistantCover;
+};
+module.exports.HomeAssistantCover = HomeAssistantCover;
+
+function HomeAssistantCover(log, data, client, type) {
+  // device info
+  this.domain = "cover"
+  this.data = data
+  this.entity_id = data.entity_id
+  if (data.attributes && data.attributes.friendly_name) {
+    this.name = data.attributes.friendly_name
+  }else{
+    this.name = data.entity_id.split('.').pop().replace(/_/g, ' ')
+  }
+  if (data.attributes && data.attributes.homebridge_cover_type && (
+    data.attributes.homebridge_cover_type === 'rollershutter' ||
+    data.attributes.homebridge_cover_type === 'garage_door'
+  )) {
+    this.cover_type = data.attributes.homebridge_cover_type;
+  } else {
+    throw new Error('You must provide the `homebridge_cover_type\' property ' +
+                    'in the customise section of your Home Assistant config. ' +
+                    'Set it to either `rollershutter\' or `garage_door\'.');
+  }
+
+  this.client = client
+  this.log = log;
+}
+
+HomeAssistantCover.prototype = {
+  onEvent: function(old_state, new_state) {
+    var coverState = new_state.attributes.current_position == 100 ? 1 : 0;
+    this.coverService.getCharacteristic(Characteristic.CurrentDoorState)
+        .setValue(garageState, null, 'internal');
+    this.coverService.getCharacteristic(Characteristic.TargetDoorState)
+        .setValue(garageState, null, 'internal');
+  },
+  getCoverState: function(callback){
+    this.client.fetchState(this.entity_id, function(data){
+      if (data) {
+        coverState = data.state == 'closed'
+        callback(null, coverState)
+      }else{
+        callback(communicationError)
+      }
+    }.bind(this))
+  },
+  setCoverState: function(coverOn, callback, context) {
+    if (context == 'internal') {
+      callback();
+      return;
+    }
+
+    var that = this;
+    var service_data = {}
+    service_data.entity_id = this.entity_id
+
+    if (coverOn) {
+      this.log("Setting cover state on the '"+this.name+"' to closed");
+
+      this.client.callService(this.domain, 'close', service_data, function(data){
+        if (data) {
+          that.log("Successfully set cover state on the '"+that.name+"' to closed");
+          callback()
+        }else{
+          callback(communicationError)
+        }
+      }.bind(this))
+    }else{
+      this.log("Setting cover state on the '"+this.name+"' to open");
+
+      this.client.callService(this.domain, 'open', service_data, function(data){
+        if (data) {
+          that.log("Successfully set cover state on the '"+that.name+"' to open");
+          callback()
+        }else{
+          callback(communicationError)
+        }
+      }.bind(this))
+    }
+  },
+  getServices: function() {
+    this.coverService = new Service.GarageDoorOpener();
+
+    var informationService = new Service.AccessoryInformation();
+    informationService
+        .setCharacteristic(Characteristic.Manufacturer, "Home Assistant")
+        .setCharacteristic(Characteristic.SerialNumber, "xxx");
+    if(this.cover_type === 'garage_door') {
+        informationService.setCharacteristic(Characteristic.Model, "Garage Door");
+    } else {
+        informationService.setCharacteristic(Characteristic.Model, "Rollershutter");
+    }
+
+      this.coverService
+        .getCharacteristic(Characteristic.CurrentDoorState)
+        .on('get', this.getCoverState.bind(this));
+
+      this.coverService
+        .getCharacteristic(Characteristic.TargetDoorState)
+        .on('get', this.getCoverState.bind(this))
+        .on('set', this.setCoverState.bind(this));
+
+    return [informationService, this.coverService];
+  }
+
+}

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = function(homebridge) {
   HomeAssistantRollershutter = require('./accessories/rollershutter')(Service, Characteristic, communicationError);
   HomeAssistantMediaPlayer = require('./accessories/media_player')(Service, Characteristic, communicationError);
   HomeAssistantFan = require('./accessories/fan')(Service, Characteristic, communicationError);
+  HomeAssistantCover = require('./accessories/cover')(Service, Characteristic, communicationError);
 
   homebridge.registerPlatform("homebridge-homeassistant", "HomeAssistant", HomeAssistantPlatform, false);
 }
@@ -186,6 +187,8 @@ HomeAssistantPlatform.prototype = {
           accessory = new HomeAssistantSwitch(that.log, entity, that, 'input_boolean')
         }else if (entity_type == 'fan'){
           accessory = new HomeAssistantFan(that.log, entity, that)
+        }else if (entity_type == 'cover'){
+          accessory = new HomeAssistantCover(that.log, entity, that)
         }
 
         if (accessory) {

--- a/index.js
+++ b/index.js
@@ -189,15 +189,12 @@ HomeAssistantPlatform.prototype = {
           accessory = new HomeAssistantSwitch(that.log, entity, that, 'input_boolean')
         }else if (entity_type == 'fan'){
           accessory = new HomeAssistantFan(that.log, entity, that)
-<<<<<<< HEAD
         }else if (entity_type == 'cover'){
           accessory = new HomeAssistantCover(that.log, entity, that)
-=======
         }else if (entity_type == 'sensor'){
           accessory = HomeAssistantSensorFactory(that.log, entity, that)
         }else if (entity_type == 'binary_sensor' && entity.attributes && entity.attributes.sensor_class) {
           accessory = HomeAssistantBinarySensorFactory(that.log, entity, that)
->>>>>>> master
         }
 
         if (accessory) {


### PR DESCRIPTION
Hi,

I've added support for Covers as per #38, basing code off the existing Rollershutter and Garage Door components. Covers are exposed as Garage Doors with binary open/close states. Covers must have their 'real' type specified in the Home Assistant `configuration.yaml` customize section, under the `homebridge_cover_type` key.

I've noticed work on this has also been completed in pull #34. As for which one should be merged, I'm not quite sure. I began work on my patch without realising work had already begun, and only found out about the existing PR at the last minute. I thought I'd submit this PR anyway just in case.

The patch works fine on my MQTT shutters in Home Assistant, however I have no smart garage doors to test with so someone else would have to test those. It shouldn't matter in theory as shutters and garage doors have the same interface under Cover.