### PR TITLE
Improve cover instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ automatically. Easy peasey.
 Here's a list of the devices that are currently exposed:
 
 * **Binary Sensor** - door, leak, moisture, motion, smoke, and window state
-* **Cover** - exposed as a garage door (see notes)
+* **Cover** - exposed as a garage door or window covering (see notes)
 * **Fan** - on/off/speed
 * **Input boolean** - on/off
 * **Lights** - on/off/brightness
@@ -56,9 +56,9 @@ support on/off they will be turned on and off.
 
 ### Cover Support
 
-Covers on your Home Assistant will appear as garage doors, however their real
-type must be specified in the `customize` section of your Home Assistant's
-`configuration.yaml`. Refer to the following example:
+Covers on your Home Assistant will appear as a garage door by default. In order 
+to do change this you may specify its type in the `customize` section of your
+Home Assistant's `configuration.yaml`. Refer to the following example:
 
 ```
 customize:


### PR DESCRIPTION
This PR clarifies the fact that the `cover` component uses a garage door by default (I personally thought that this module auto-detected the type at first).

Also, the wording led me to believe that rollershutters were also exposed as a garage door, which is not true if you configure it as per the original instructions.