### PR TITLE
Fix logging config check

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function HomeAssistantPlatform(log, config, api){
     this.password = config.password;
     this.supportedTypes = config.supported_types || ['binary_sensor', 'cover', 'fan', 'input_boolean', 'light', 'lock', 'media_player', 'scene', 'sensor', 'switch'];
     this.foundAccessories = [];
-    this.logging = config.logging != undefined ? config.logging : true;
+    this.logging = config.logging !== undefined ? config.logging : true;
 
     this.log = log;
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function HomeAssistantPlatform(log, config, api){
     this.password = config.password;
     this.supportedTypes = config.supported_types || ['binary_sensor', 'cover', 'fan', 'input_boolean', 'light', 'lock', 'media_player', 'scene', 'sensor', 'switch'];
     this.foundAccessories = [];
-    this.logging = config.logging || true;
+    this.logging = config.logging != undefined ? config.logging : true;
 
     this.log = log;
 


### PR DESCRIPTION
Currently if you add "logging": false to your config, events are still logged and it has no affect.
This is because config.logging || true always evaluates true.
This pull request corrects the check.