### PR TITLE
Add climate support for generic_thermostat

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here's a list of the devices that are currently exposed:
 * **Scenes** - exposed as an on/off switch
 * **Sensors** - carbon dioxide (CO2), humidity, light, temperature sensors
 * **Switches** - on/off
-* **Climate** - support generic_thermostat (see notes)
+* **Climate** - support climate, generic_thermostat (see notes)
 * **Device Tracker** - occupancy sensor
 
 ### Binary Sensor Support

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Here's a list of the devices that are currently exposed:
 * **Scenes** - exposed as an on/off switch
 * **Sensors** - carbon dioxide (CO2), humidity, light, temperature sensors
 * **Switches** - on/off
+* **Climate** - support generic_thermostat (see notes)
+* **Device Tracker** - occupancy sensor
 
 ### Binary Sensor Support
 
@@ -78,6 +80,22 @@ Carbon dioxide (CO2), humidity, light and temperature sensors are currently supp
 - Temperature sesnsors will be found if an entity has its unit of measurement set to `°C` or `°C`.
 - Humidity sensors will be found if an entity has its unit of measurement set to `%` and has an entity ID containing `humidity` _or_ `homebridge_sensor_type` is set to `humidity` on the entity.
 - Carbon Dioxide (CO2) sensors will be found if an entity has its unit of measurement set to `ppm` and has an entity ID containing `co2` _or_ `homebridge_sensor_type` is set to `co2` on the entity.
+
+### Climate Support
+
+Climate on your Home Assistant will appear in HomeKit as Thermostat. If you are using
+a generic_thermostat, you have to change type in the `customize` section of your
+Home Assistant's `configuration.yaml`. Refer to the following example:
+
+```
+customize:
+  climate.thermostat:
+    homebridge_climate_type: generic
+```
+
+## Device Tracker
+
+Device Tracker on your Home Assistant will appear in HomeKit as occupancy sensor.
 
 ## Installation
 

--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -179,11 +179,11 @@ class HomeAssistantClimate {
 
 class HomeAssistantClimatePhysical extends HomeAssistantClimate {
     constructor(log, data, client, service, characteristic, currentHeatingCoolingState, targetHeatingCoolingState, currentTemperature, targetTemperature, temperatureDisplayUnits) {
+    super(log, data, client, service, characteristic, currentHeatingCoolingState, targetHeatingCoolingState, currentTemperature, targetTemperature, temperatureDisplayUnits);
     this.currentRelativeHumidity = Characteristic.CurrentRelativeHumidity;
     this.targetRelativeHumidity = Characteristic.TargetRelativeHumidity;
     this.coolingThresholdTemperature = Characteristic.CoolingThresholdTemperature;
     this.heatingThresholdTemperature = Characteristic.HeatingThresholdTemperature;
-    this.name = Characteristic.Name;
   }
     // TODO
 }

--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -32,8 +32,10 @@ class HomeAssistantClimate {
     }
 
     onEvent(old_state, new_state) {
-        this.thermostatService.getCharacteristic(this.characteristic)
-            .setValue(new_state.attributes.current_temperature , null, 'internal');
+        this.thermostatService.getCharacteristic(Characteristic.CurrentTemperature)
+            .setValue(new_state.attributes.current_temperature , null, 'internal'),
+        this.thermostatService.getCharacteristic(Characteristic.TargetTemperature)
+            .setValue(new_state.attributes.temperature , null, 'internal');
     }
     identify(callback) {
         this.log('identifying: ' + this.name);
@@ -175,17 +177,39 @@ class HomeAssistantClimate {
     }
 }
 
+class HomeAssistantClimatePhysical extends HomeAssistantClimate {
+    constructor(log, data, client, service, characteristic, currentHeatingCoolingState, targetHeatingCoolingState, currentTemperature, targetTemperature, temperatureDisplayUnits) {
+    this.currentRelativeHumidity = Characteristic.CurrentRelativeHumidity;
+    this.targetRelativeHumidity = Characteristic.TargetRelativeHumidity;
+    this.coolingThresholdTemperature = Characteristic.CoolingThresholdTemperature;
+    this.heatingThresholdTemperature = Characteristic.HeatingThresholdTemperature;
+    this.name = Characteristic.Name;
+  }
+    // TODO
+}
+
 function HomeAssistantClimateFactory(log, data, client) {
     if (!(data.attributes)) {
         return null;
     }
-    return new HomeAssistantClimate(log, data, client,
-      Service.Thermostat,
-      Characteristic.CurrentHeatingCoolingState,
-      Characteristic.TargetHeatingCoolingState,
-      Characteristic.CurrentTemperature,
-      Characteristic.TargetTemperature,
-      Characteristic.TemperatureDisplayUnits);
+
+    if (data.attributes.homebridge_climate_type === 'generic') {
+        return new HomeAssistantClimate(log, data, client,
+                Service.Thermostat,
+                Characteristic.CurrentHeatingCoolingState,
+                Characteristic.TargetHeatingCoolingState,
+                Characteristic.CurrentTemperature,
+                Characteristic.TargetTemperature,
+                Characteristic.TemperatureDisplayUnits);
+    } else {
+        return new HomeAssistantClimatePhysical(log, data, client,
+                Service.Thermostat,
+                Characteristic.CurrentHeatingCoolingState,
+                Characteristic.TargetHeatingCoolingState,
+                Characteristic.CurrentTemperature,
+                Characteristic.TargetTemperature,
+                Characteristic.TemperatureDisplayUnits);
+    }
 }
 
 function HomeAssistantClimateFactoryPlatform(oService, oCharacteristic, oCommunicationError) {

--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -1,0 +1,200 @@
+'use strict';
+
+var Service;
+var Characteristic;
+var communicationError;
+
+class HomeAssistantClimate {
+    constructor(log, data, client, service, characteristic, currentHeatingCoolingState, targetHeatingCoolingState, currentTemperature, targetTemperature, temperatureDisplayUnits) {
+        // device info
+        this.domain = 'climate';
+        this.data = data;
+        this.entity_id = data.entity_id;
+        this.uuid_base = data.entity_id;
+        if (data.attributes && data.attributes.friendly_name) {
+            this.name = data.attributes.friendly_name;
+        } else {
+            this.name = data.entity_id.split('.').pop().replace(/_/g, ' ');
+        }
+
+        this.entity_type = data.entity_id.split('.')[0];
+
+        this.client = client;
+        this.log = log;
+
+        this.service = service;
+        this.characteristic = characteristic;
+        this.currentHeatingCoolingState = currentHeatingCoolingState;
+        this.targetHeatingCoolingState = targetHeatingCoolingState;
+        this.currentTemperature = currentTemperature;
+        this.targetTemperature = targetTemperature;
+        this.temperatureDisplayUnits = temperatureDisplayUnits;
+    }
+
+    onEvent(old_state, new_state) {
+        this.thermostatService.getCharacteristic(this.characteristic)
+            .setValue(new_state.attributes.current_temperature , null, 'internal');
+    }
+    identify(callback) {
+        this.log('identifying: ' + this.name);
+        callback();
+    }
+    getCurrentTemperature(callback) {
+        this.log('fetching state for: ' + this.name);
+        this.client.fetchState(this.entity_id, function (data) {
+            if (data) {
+                callback(null, data.attributes.current_temperature);
+            } else {
+                callback(communicationError);
+            }
+        }.bind(this));
+    }
+    getTargetTemperature(callback) {
+        var targetTemp;
+        this.client.fetchState(this.entity_id, function (data) {
+            if (data) {
+                if (!data.attributes.temperature || data.attributes.temperature < '10') {
+                    targetTemp = '10';
+                } else if (data.attributes.temperature < data.attributes.min_temp) {
+                    targetTemp = data.attributes.min_temp;
+                } else if (data.attributes.temperature > '38') {
+                    targetTemp = data.attributes.max_temp || '38';
+                } else {
+                    targetTemp = data.attributes.temperature;
+                }
+                this.log("target Temp is : " + targetTemp);
+                callback(null, targetTemp);
+            } else {
+                callback(communicationError);
+            }
+        }.bind(this));
+    }
+    setTargetTemperature(targetTemperature, callback, context) {
+        if (context == 'internal') {
+            callback();
+            return;
+        }
+
+        var service_data = {};
+        service_data.entity_id = this.entity_id;
+
+        service_data.temperature = targetTemperature;
+        this.log('Setting temperature on \''+this.name+'\' to \''+service_data.temperature+'\'');
+        this.client.callService(this.domain, 'set_temperature', service_data, function(data){
+            if (data) {
+                callback();
+            } else {
+                callback(communicationError);
+            }
+        }.bind(this));
+    }
+    getCurrentHeatingCoolingState(callback) {
+        this.client.fetchState(this.entity_id, function(data){
+            if (data) {
+                callback(null, ((data.Mode == 'Auto') ? 3 : 1));
+            } else {
+                callback(communicationError);
+            }
+        }.bind(this));
+    }
+    getTargetHeatingCoolingState(callback) {
+        this.client.fetchState(this.entity_id, function(data){
+            if (data) {
+                callback(null, ((data.Mode == 'Auto') ? 3 : 1));
+            } else {
+                callback(communicationError);
+            }
+        }.bind(this));
+    }
+    setTargetHeatingCoolingState(heatingState, callback, context) {
+        var service = ''
+            if (context == 'internal') {
+                callback();
+                return;
+            }
+        this.log("Heating State : " + heatingState);
+        if ( heatingState == '0' ) {
+            service = 'off';
+        } else if ( heatingState == '1' ) {
+            service = 'heat';
+        } else if ( heatingState == '2' ) {
+            service = 'cool';
+        } else if ( heatingState == '3' ) {
+            service = 'auto';
+        }
+        this.client.callService(this.domain, 'set_operation_mode', service , function(data){
+            if (data) {
+                this.log('Successfully set cooling state');
+                callback();
+            } else {
+                callback(communicationError);
+            }
+        }.bind(this));
+    }
+    getTemperatureDisplayUnits(callback) {
+        this.client.fetchState(this.entity_id, function(data){
+            if (data.attributes.unit_of_measurement == '°C') {
+                callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS);
+            } else if (data.attributes.unit_of_measurement == '°F') {
+                callback(null, Characteristic.TemperatureDisplayUnits.FAHRENHEIT);
+            } else {
+                callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS);
+            }
+        }.bind(this));
+    }
+
+    getServices() {
+        this.thermostatService = new Service.Thermostat();
+
+        this.thermostatService
+            .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+            .on( 'get', this.getCurrentHeatingCoolingState.bind(this));
+        this.thermostatService
+            .getCharacteristic(Characteristic.TargetHeatingCoolingState)
+            .on( 'get', this.getTargetHeatingCoolingState.bind(this))
+            .on( 'set', this.setTargetHeatingCoolingState.bind(this));
+        this.thermostatService
+            .getCharacteristic(Characteristic.CurrentTemperature)
+            .on( 'get', this.getCurrentTemperature.bind(this));
+        this.thermostatService
+            .getCharacteristic(Characteristic.TargetTemperature)
+            .on( 'get', this.getTargetTemperature.bind(this))
+            .on( 'set', this.setTargetTemperature.bind(this));
+        this.thermostatService
+            .getCharacteristic(Characteristic.TemperatureDisplayUnits)
+            .on( 'get', this.getTemperatureDisplayUnits.bind(this));
+
+        const informationService = new Service.AccessoryInformation()
+
+        informationService
+            .setCharacteristic(Characteristic.Manufacturer, 'Home Assistant')
+            .setCharacteristic(Characteristic.Model, 'Generic Thermostat')
+            .setCharacteristic(Characteristic.SerialNumber, this.entity_id);
+
+        return [informationService, this.thermostatService];
+    }
+}
+
+function HomeAssistantClimateFactory(log, data, client) {
+    if (!(data.attributes)) {
+        return null;
+    }
+    return new HomeAssistantClimate(log, data, client,
+      Service.Thermostat,
+      Characteristic.CurrentHeatingCoolingState,
+      Characteristic.TargetHeatingCoolingState,
+      Characteristic.CurrentTemperature,
+      Characteristic.TargetTemperature,
+      Characteristic.TemperatureDisplayUnits);
+}
+
+function HomeAssistantClimateFactoryPlatform(oService, oCharacteristic, oCommunicationError) {
+    Service = oService;
+    Characteristic = oCharacteristic;
+    communicationError = oCommunicationError;
+
+    return HomeAssistantClimateFactory;
+}
+
+module.exports = HomeAssistantClimateFactoryPlatform;
+module.exports.HomeAssistantClimateFactory = HomeAssistantClimateFactory;

--- a/index.js
+++ b/index.js
@@ -17,12 +17,13 @@ let HomeAssistantMediaPlayer;
 let HomeAssistantSensorFactory;
 let HomeAssistantSwitch;
 let HomeAssistantDeviceTrackerFactory;
+let HomeAssistantClimateFactory;
 
 function HomeAssistantPlatform(log, config, api) {
   // auth info
   this.host = config.host;
   this.password = config.password;
-  this.supportedTypes = config.supported_types || ['binary_sensor', 'cover', 'device_tracker', 'fan', 'input_boolean', 'light', 'lock', 'media_player', 'scene', 'sensor', 'switch'];
+  this.supportedTypes = config.supported_types || ['binary_sensor', 'climate', 'cover', 'device_tracker', 'fan', 'input_boolean', 'light', 'lock', 'media_player', 'scene', 'sensor', 'switch'];
   this.foundAccessories = [];
   this.logging = config.logging !== undefined ? config.logging : true;
 
@@ -175,6 +176,8 @@ HomeAssistantPlatform.prototype = {
           accessory = HomeAssistantSensorFactory(that.log, entity, that);
         } else if (entityType === 'device_tracker') {
           accessory = HomeAssistantDeviceTrackerFactory(that.log, entity, that);
+        } else if (entityType === 'climate') {
+          accessory = HomeAssistantClimateFactory(that.log, entity, that);
         } else if (entityType === 'media_player' && entity.attributes && entity.attributes.supported_features) {
           accessory = new HomeAssistantMediaPlayer(that.log, entity, that);
         } else if (entityType === 'binary_sensor' && entity.attributes && entity.attributes.device_class) {
@@ -205,6 +208,7 @@ function HomebridgeHomeAssistant(homebridge) {
   HomeAssistantSensorFactory = require('./accessories/sensor')(Service, Characteristic, communicationError);
   HomeAssistantBinarySensorFactory = require('./accessories/binary_sensor')(Service, Characteristic, communicationError);
   HomeAssistantDeviceTrackerFactory = require('./accessories/device_tracker')(Service, Characteristic, communicationError);
+  HomeAssistantClimateFactory = require('./accessories/climate')(Service, Characteristic, communicationError);
   /* eslint-enable global-require */
 
   homebridge.registerPlatform('homebridge-homeassistant', 'HomeAssistant', HomeAssistantPlatform, false);


### PR DESCRIPTION
Add support for generic_thermostat.

It's an alpha version but it's working on my side for my personal usage. 

 - physical thermostat not tested.
 - a/c mode not tested.
 - It's seems it fails if min_temp is defined under 10°C. HomeHit allow from 10° to 38°.
 - I can't find away mode in hass for the generic_thermostat, but it would be great to add if it exists.
 - Set Mode has no action on  Generic Thermostat, but I think the code is OK.