### PR TITLE
Assume feature is not supported if doesn't exist

### DIFF
--- a/accessories/light.js
+++ b/accessories/light.js
@@ -114,9 +114,9 @@ HomeAssistantLight.prototype = {
     XY_COLOR: 64,
   }),
   is_supported(feature) {
-    // If the supported_features attribute doesn't exist, assume supported
+    // If the supported_features attribute doesn't exist, assume not supported
     if (this.data.attributes.supported_features === undefined) {
-      return true;
+      return false;
     }
 
     return (this.data.attributes.supported_features & feature) > 0;


### PR DESCRIPTION
When this check was first introduced HA didn't expose the attribute yet so we
assumed the feature exists so HomeBridge users could make use of it.
If no special feature (RGB, brightness, etc.) is supported, i.e. the attribute
is 0, HA doesn't expose the supported_feature attribute at all. If that is the
case, we should assume the features is not supported.