### PR TITLE
Correctly reflect input_boolean status on homebridge startup

### DIFF
--- a/accessories/switch.js
+++ b/accessories/switch.js
@@ -94,7 +94,7 @@ HomeAssistantSwitch.prototype = {
           .setCharacteristic(Characteristic.Model, model)
           .setCharacteristic(Characteristic.SerialNumber, this.entity_id);
 
-    if (this.domain === 'switch') {
+    if (this.domain === 'switch' || this.domain === 'input_boolean') {
       this.switchService
           .getCharacteristic(Characteristic.On)
           .on('get', this.getPowerState.bind(this))


### PR DESCRIPTION
Fixes bug where homebridge starts up and an input boolean switch which is on in homeassistant shows off in homekit until toggled on.