### PR TITLE
Renamed sensor_class to device_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Here's a list of the devices that are currently exposed:
 
 ### Binary Sensor Support
 
-Binary Sensors must have a `sensor_class` set. Accepted `sensor_class`es are `moisture`, `motion`, `occupancy`, `opening` and `smoke`.
+Binary Sensors must have a `device_class` set. Accepted `device_class`es are `moisture`, `motion`, `occupancy`, `opening` and `smoke`.
 
-For binary sensors with the `opening` `sensor_class` you can also set `homebridge_opening_type` to `window` to have the entity display as a window instead of a door to Homebridge.
+For binary sensors with the `opening` `device_class` you can also set `homebridge_opening_type` to `window` to have the entity display as a window instead of a door to Homebridge.
 
 ### Cover Support
 

--- a/accessories/binary_sensor.js
+++ b/accessories/binary_sensor.js
@@ -59,7 +59,7 @@ class HomeAssistantBinarySensor {
 
     informationService
           .setCharacteristic(Characteristic.Manufacturer, 'Home Assistant')
-          .setCharacteristic(Characteristic.Model, `${toTitleCase(this.data.attributes.sensor_class)} Binary Sensor`)
+          .setCharacteristic(Characteristic.Model, `${toTitleCase(this.data.attributes.device_class)} Binary Sensor`)
           .setCharacteristic(Characteristic.SerialNumber, this.entity_id);
 
     return [informationService, this.sensorService];
@@ -67,10 +67,10 @@ class HomeAssistantBinarySensor {
 }
 
 function HomeAssistantBinarySensorFactory(log, data, client) {
-  if (!(data.attributes && data.attributes.sensor_class)) {
+  if (!(data.attributes && data.attributes.device_class)) {
     return null;
   }
-  switch (data.attributes.sensor_class) {
+  switch (data.attributes.device_class) {
     case 'moisture':
       return new HomeAssistantBinarySensor(log, data, client,
                                            Service.LeakSensor,
@@ -102,7 +102,7 @@ function HomeAssistantBinarySensorFactory(log, data, client) {
                                            Characteristic.SmokeDetected.SMOKE_DETECTED,
                                            Characteristic.SmokeDetected.SMOKE_NOT_DETECTED);
     default:
-      log.error(`'${data.entity_id}' has a sensor_class of '${data.attributes.sensor_class}' which is not supported by ` +
+      log.error(`'${data.entity_id}' has a device_class of '${data.attributes.device_class}' which is not supported by ` +
                 'homebridge-homeassistant. Supported classes are \'moisture\', \'motion\', \'occupancy\', \'opening\' and \'smoke\'. ' +
                 'See the README.md for more information.');
       return null;

--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ HomeAssistantPlatform.prototype = {
           accessory = HomeAssistantDeviceTrackerFactory(that.log, entity, that);
         } else if (entityType === 'media_player' && entity.attributes && entity.attributes.supported_features) {
           accessory = new HomeAssistantMediaPlayer(that.log, entity, that);
-        } else if (entityType === 'binary_sensor' && entity.attributes && entity.attributes.sensor_class) {
+        } else if (entityType === 'binary_sensor' && entity.attributes && entity.attributes.device_class) {
           accessory = HomeAssistantBinarySensorFactory(that.log, entity, that);
         }
 


### PR DESCRIPTION
The sensor_class attribute was renamed in Home Assistant to device_class. Update
name here as well.