### PR TITLE
Update media_player.js

### DIFF
--- a/accessories/media_player.js
+++ b/accessories/media_player.js
@@ -30,19 +30,17 @@ function HomeAssistantMediaPlayer(log, data, client) {
   } else {
     this.name = data.entity_id.split('.').pop().replace(/_/g, ' ');
   }
-  
+
   if ((this.supportedFeatures | SUPPORT_PAUSE) === this.supportedFeatures) {
     this.onState = 'playing';
     this.offState = 'paused';
     this.onService = 'media_play';
     this.offService = 'media_pause';
-  }
-  else if ((this.supportedFeatures | SUPPORT_STOP) === this.supportedFeatures) {
+  } else if ((this.supportedFeatures | SUPPORT_STOP) === this.supportedFeatures) {
     this.onState = 'playing';
     this.offState = 'idle';
     this.onService = 'media_play';
     this.offService = 'media_stop';
-  
   } else if ((this.supportedFeatures | SUPPORT_TURN_ON) === this.supportedFeatures &&
              (this.supportedFeatures | SUPPORT_TURN_OFF) === this.supportedFeatures) {
     this.onState = 'on';

--- a/accessories/media_player.js
+++ b/accessories/media_player.js
@@ -30,17 +30,19 @@ function HomeAssistantMediaPlayer(log, data, client) {
   } else {
     this.name = data.entity_id.split('.').pop().replace(/_/g, ' ');
   }
-
-  if ((this.supportedFeatures | SUPPORT_STOP) === this.supportedFeatures) {
-    this.onState = 'playing';
-    this.offState = 'idle';
-    this.onService = 'media_play';
-    this.offService = 'media_stop';
-  } else if ((this.supportedFeatures | SUPPORT_PAUSE) === this.supportedFeatures) {
+  
+  if ((this.supportedFeatures | SUPPORT_PAUSE) === this.supportedFeatures) {
     this.onState = 'playing';
     this.offState = 'paused';
     this.onService = 'media_play';
     this.offService = 'media_pause';
+  }
+  else if ((this.supportedFeatures | SUPPORT_STOP) === this.supportedFeatures) {
+    this.onState = 'playing';
+    this.offState = 'idle';
+    this.onService = 'media_play';
+    this.offService = 'media_stop';
+  
   } else if ((this.supportedFeatures | SUPPORT_TURN_ON) === this.supportedFeatures &&
              (this.supportedFeatures | SUPPORT_TURN_OFF) === this.supportedFeatures) {
     this.onState = 'on';


### PR DESCRIPTION
PAUSE should be prioritized more than STOP. For example, I'm using MPC-HC plugin (https://home-assistant.io/components/media_player.mpchc/). It supports both STOP and PAUSE, but since STOP is prioritized more. I can't use PAUSE ability anymore because 'OFF' state is give to STOP.