### PR TITLE
Fix fan medium speed

### DIFF
--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -107,7 +107,7 @@ HomeAssistantFan.prototype = {
     if (speed <= 25) {
       serviceData.speed = 'low';
     } else if (speed <= 75) {
-      serviceData.speed = 'med';
+      serviceData.speed = 'medium';
     } else if (speed <= 100) {
       serviceData.speed = 'high';
     }


### PR DESCRIPTION
The hass service calls for `'medium'`, not `'med'`: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/fan/__init__.py#L47

See also: https://community.home-assistant.io/t/z-wave-fan-control/4143/18