### PR TITLE
Allow setting climate mode & set target temperature min/max/step from hass data

### DIFF
--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -86,7 +86,7 @@ HomeAssistantClimate.prototype = {
             state = Characteristic.TargetHeatingCoolingState.OFF;
             break;
         }
-	    callback(null, state);
+        callback(null, state);
       } else {
         callback(communicationError);
       }
@@ -94,6 +94,10 @@ HomeAssistantClimate.prototype = {
   },
 
   setTargetHeatingCoolingState: function (value, callback, context) {
+    if (context === 'internal') {
+      callback();
+      return;
+    }
     var serviceData = {};
     serviceData.entity_id = this.entity_id;
 
@@ -109,6 +113,7 @@ HomeAssistantClimate.prototype = {
         mode = 'heat';
         break;
       case Characteristic.TargetHeatingCoolingState.OFF:
+      default:
         mode = 'idle';
         break;
     }
@@ -118,7 +123,7 @@ HomeAssistantClimate.prototype = {
 
     var that = this;
 
-    this.client.callService(this.domain, 'set_operation_mode', serviceData, function(data) {
+    this.client.callService(this.domain, 'set_operation_mode', serviceData, function (data) {
       if (data) {
         that.log(`Successfully set current heating cooling state of '${that.name}'`);
         callback();

--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -52,20 +52,13 @@ HomeAssistantClimate.prototype = {
     var that = this;
     var serviceData = {};
     serviceData.entity_id = this.entity_id;
+    serviceData.temperature = value;
 
-        // clamp the values
-    if (value < 6) {
-      serviceData.temperature = 6;
-    } else if (value > 30) {
-      serviceData.temperature = 30;
-    } else {
-      serviceData.temperature = value;
-    }
     this.log(`Setting temperature on the '${this.name}' to ${serviceData.temperature}`);
 
     this.client.callService(this.domain, 'set_temperature', serviceData, function (data) {
       if (data) {
-        that.log(`Successfully set temperature of '${that.name}' hi`);
+        that.log(`Successfully set temperature of '${that.name}'`);
         callback();
       } else {
         callback(communicationError);
@@ -96,11 +89,27 @@ HomeAssistantClimate.prototype = {
 
     this.ThermostatService
           .getCharacteristic(Characteristic.CurrentTemperature)
-          .setProps({ minValue: 4.5, maxValue: 30.5, minStep: 0.1 })
           .on('get', this.getCurrentTemp.bind(this));
+
+    var minTemp = 7.0;
+    var maxTemp = 35.0;
+    var tempStep = 0.5;
+
+    if (this.data && this.data.attributes) {
+      if (this.data.attributes.min_temp) {
+        minTemp = this.data.attributes.min_temp;
+      }
+      if (this.data.attributes.max_temp) {
+        maxTemp = this.data.attributes.max_temp;
+      }
+      if (this.data.attributes.target_temp_step) {
+        tempStep = this.data.attributes.target_temp_step;
+      }
+    }
 
     this.ThermostatService
           .getCharacteristic(Characteristic.TargetTemperature)
+          .setProps({ minValue: minTemp, maxValue: maxTemp, minStep: tempStep })
           .on('get', this.getTargetTemp.bind(this))
           .on('set', this.setTargetTemp.bind(this));
 


### PR DESCRIPTION
This PR includes 2 enhancements to the climate accessory:

1. The ability to set the operation mode of the climate device. 
Currently, the 4 HomeKit thermostat modes are Off, Heat, Cool & Auto, these are respectively mapped to the home-assistant climate modes of idle, heat, cool & auto.
In addition, the HK mode is now properly set based on the home-assistant operation mode.
(in future it will be nice to customise this mapping in the homebridge config as climate devices in hass may have different modes (e.g. 'dry', 'fan_only'), but this is a good first step)

2. The target temperature minimum temperature, maximum temperature and temperature step are now retrieved from the home-assistant climate device's attributes, rather than being hard coded in the climate accessory.

I removed the min/max values which were previously set on the current temperature attribute, as it's possible that those values will be outside the min/max target temperatures of the climate device, and the current temperature attribute itself seems to have [sensible defaults]( https://github.com/KhaosT/HAP-NodeJS/blob/master/lib/gen/HomeKitTypes.js#L684-L685).
