### PR TITLE
Add light sensors with homebridge_sensor_type = light

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The switch will automatically turn off shortly after turning on.
 
 Carbon dioxide (CO2), humidity, light and temperature sensors are currently supported.
 
-- Light sensors will be found if an entity has its unit of measurement set to `lux`.
+- Light sensors will be found if an entity has its unit of measurement set to `lux` _or_ `homebridge_sensor_type` is set to `light` on the entity.
 - Temperature sensors will be found if an entity has its unit of measurement set to `°C` or `°C`.
 - Humidity sensors will be found if an entity has its unit of measurement set to `%` and has an entity ID containing `humidity` _or_ `homebridge_sensor_type` is set to `humidity` on the entity.
 - Carbon Dioxide (CO2) sensors will be found if an entity has its unit of measurement set to `ppm` and has an entity ID containing `co2` _or_ `homebridge_sensor_type` is set to `co2` on the entity.

--- a/accessories/sensor.js
+++ b/accessories/sensor.js
@@ -104,7 +104,7 @@ function HomeAssistantSensorFactory(log, data, client) {
   } else if (data.attributes.unit_of_measurement === '%' && (data.entity_id.includes('humidity') || data.attributes.homebridge_sensor_type === 'humidity')) {
     service = Service.HumiditySensor;
     characteristic = Characteristic.CurrentRelativeHumidity;
-  } else if (data.attributes.unit_of_measurement === 'lux') {
+  } else if (data.attributes.unit_of_measurement === 'lux' || data.attributes.homebridge_sensor_type === 'light') {
     service = Service.LightSensor;
     characteristic = Characteristic.CurrentAmbientLightLevel;
     transformData = function transformData(dataToTransform) { // eslint-disable-line no-shadow

--- a/accessories/sensor.js
+++ b/accessories/sensor.js
@@ -104,13 +104,13 @@ function HomeAssistantSensorFactory(log, data, client) {
   } else if (data.attributes.unit_of_measurement === '%' && (data.entity_id.includes('humidity') || data.attributes.homebridge_sensor_type === 'humidity')) {
     service = Service.HumiditySensor;
     characteristic = Characteristic.CurrentRelativeHumidity;
-  } else if (data.attributes.unit_of_measurement === 'lux' || data.attributes.homebridge_sensor_type === 'light') {
+  } else if (data.attributes.unit_of_measurement.toLowerCase() === 'lux' || data.attributes.homebridge_sensor_type === 'light') {
     service = Service.LightSensor;
     characteristic = Characteristic.CurrentAmbientLightLevel;
     transformData = function transformData(dataToTransform) { // eslint-disable-line no-shadow
       return Math.max(0.0001, parseFloat(dataToTransform.state));
     };
-  } else if (data.attributes.unit_of_measurement === 'ppm' && (data.entity_id.includes('co2') || data.attributes.homebridge_sensor_type === 'co2')) {
+  } else if (data.attributes.unit_of_measurement.toLowerCase() === 'ppm' && (data.entity_id.includes('co2') || data.attributes.homebridge_sensor_type === 'co2')) {
     service = Service.CarbonDioxideSensor;
     characteristic = Characteristic.CarbonDioxideLevel;
   } else {


### PR DESCRIPTION
Add light sensors with 'lx' as unit of measurement (instead of lux), and even percentage sensors, using the `homebridge_sensor_type` with `light`.

This change also fixes #181, as now the unit comparison is done converting to lowercase the `lux` and `ppm` units.