### PR TITLE
Add `homebridge_media_player_switch` (on_off, play_pause, play_stop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ toggle them on or off.
 There are some rules to know about how on/off treats your media player. If
 your media player supports play/pause, then turning them on and off via
 HomeKit will play and pause them. If they do not support play/pause but instead
-support on/off they will be turned on and off.
+support on/off they will be turned on and off. If none of the above, HomeKit will play and stop.
+
+You can specify the mode to run by setting `homebridge_media_player_switch` to `play_pause`, `on_off` or `play_stop`, respectively.
 
 ### Scene Support
 

--- a/accessories/media_player.js
+++ b/accessories/media_player.js
@@ -31,36 +31,32 @@ function HomeAssistantMediaPlayer(log, data, client) {
     this.name = data.entity_id.split('.').pop().replace(/_/g, ' ');
   }
 
-  const support_pause = (this.supportedFeatures | SUPPORT_PAUSE) === this.supportedFeatures;
-  const support_stop = (this.supportedFeatures | SUPPORT_STOP) === this.supportedFeatures;
-  const support_on_off = ((this.supportedFeatures | SUPPORT_TURN_ON) === this.supportedFeatures &&
+  const supportPause = (this.supportedFeatures | SUPPORT_PAUSE) === this.supportedFeatures;
+  const supportStop = (this.supportedFeatures | SUPPORT_STOP) === this.supportedFeatures;
+  const supportOnOff = ((this.supportedFeatures | SUPPORT_TURN_ON) === this.supportedFeatures &&
                           (this.supportedFeatures | SUPPORT_TURN_OFF) === this.supportedFeatures);
 
-  if (this.data && this.data.attributes && this.data.attributes.homebridge_media_player_switch === 'on_off' && support_on_off) {
+  if (this.data && this.data.attributes && this.data.attributes.homebridge_media_player_switch === 'on_off' && supportOnOff) {
     this.onState = 'on';
     this.offState = 'off';
     this.onService = 'turn_on';
     this.offService = 'turn_off';
-  }
-  else if (this.data && this.data.attributes && this.data.attributes.homebridge_media_player_switch === 'play_stop' && support_stop) {
+  } else if (this.data && this.data.attributes && this.data.attributes.homebridge_media_player_switch === 'play_stop' && supportStop) {
     this.onState = 'playing';
     this.offState = 'idle';
     this.onService = 'media_play';
     this.offService = 'media_stop';
-  }
-  else if (support_pause) {
+  } else if (supportPause) {
     this.onState = 'playing';
     this.offState = 'paused';
     this.onService = 'media_play';
     this.offService = 'media_pause';
-  }
-  else if (support_stop) {
+  } else if (supportStop) {
     this.onState = 'playing';
     this.offState = 'idle';
     this.onService = 'media_play';
     this.offService = 'media_stop';
-  }
-  else if (support_on_off) {
+  } else if (supportOnOff) {
     this.onState = 'on';
     this.offState = 'off';
     this.onService = 'turn_on';
@@ -74,14 +70,14 @@ function HomeAssistantMediaPlayer(log, data, client) {
 HomeAssistantMediaPlayer.prototype = {
   onEvent(oldState, newState) {
     this.switchService.getCharacteristic(Characteristic.On)
-        .setValue(newState.state != this.offState, null, 'internal');
+        .setValue(newState.state !== this.offState, null, 'internal');
   },
   getPowerState(callback) {
     this.log(`fetching power state for: ${this.name}`);
 
     this.client.fetchState(this.entity_id, (data) => {
       if (data) {
-        const powerState = data.state != this.offState;
+        const powerState = data.state !== this.offState;
         callback(null, powerState);
       } else {
         callback(communicationError);

--- a/accessories/media_player.js
+++ b/accessories/media_player.js
@@ -31,18 +31,36 @@ function HomeAssistantMediaPlayer(log, data, client) {
     this.name = data.entity_id.split('.').pop().replace(/_/g, ' ');
   }
 
-  if ((this.supportedFeatures | SUPPORT_PAUSE) === this.supportedFeatures) {
-    this.onState = 'playing';
-    this.offState = 'paused';
-    this.onService = 'media_play';
-    this.offService = 'media_pause';
-  } else if ((this.supportedFeatures | SUPPORT_STOP) === this.supportedFeatures) {
+  const support_pause = (this.supportedFeatures | SUPPORT_PAUSE) === this.supportedFeatures;
+  const support_stop = (this.supportedFeatures | SUPPORT_STOP) === this.supportedFeatures;
+  const support_on_off = ((this.supportedFeatures | SUPPORT_TURN_ON) === this.supportedFeatures &&
+                          (this.supportedFeatures | SUPPORT_TURN_OFF) === this.supportedFeatures);
+
+  if (this.data && this.data.attributes && this.data.attributes.homebridge_media_player_switch === 'on_off' && support_on_off) {
+    this.onState = 'on';
+    this.offState = 'off';
+    this.onService = 'turn_on';
+    this.offService = 'turn_off';
+  }
+  else if (this.data && this.data.attributes && this.data.attributes.homebridge_media_player_switch === 'play_stop' && support_stop) {
     this.onState = 'playing';
     this.offState = 'idle';
     this.onService = 'media_play';
     this.offService = 'media_stop';
-  } else if ((this.supportedFeatures | SUPPORT_TURN_ON) === this.supportedFeatures &&
-             (this.supportedFeatures | SUPPORT_TURN_OFF) === this.supportedFeatures) {
+  }
+  else if (support_pause) {
+    this.onState = 'playing';
+    this.offState = 'paused';
+    this.onService = 'media_play';
+    this.offService = 'media_pause';
+  }
+  else if (support_stop) {
+    this.onState = 'playing';
+    this.offState = 'idle';
+    this.onService = 'media_play';
+    this.offService = 'media_stop';
+  }
+  else if (support_on_off) {
     this.onState = 'on';
     this.offState = 'off';
     this.onService = 'turn_on';
@@ -56,14 +74,14 @@ function HomeAssistantMediaPlayer(log, data, client) {
 HomeAssistantMediaPlayer.prototype = {
   onEvent(oldState, newState) {
     this.switchService.getCharacteristic(Characteristic.On)
-        .setValue(newState.state === this.onState, null, 'internal');
+        .setValue(newState.state != this.offState, null, 'internal');
   },
   getPowerState(callback) {
     this.log(`fetching power state for: ${this.name}`);
 
     this.client.fetchState(this.entity_id, (data) => {
       if (data) {
-        const powerState = data.state === this.onState;
+        const powerState = data.state != this.offState;
         callback(null, powerState);
       } else {
         callback(communicationError);


### PR DESCRIPTION
## Introduction

The logic of behavior mode for the `media_player` switches is too rigid, and for many media player platforms, which implement multiple features (pause, turn_on/off, stop...), this makes theses switches not very useful, requiring extra switches to model the real needs.

## Description

A new homebridge keyword `homebridge_media_player_switch` for customising the media players in HA is proposed, to specify the behaviour mode, between `play_pause`, `on_off` or `play_stop` options.

Also, the **change state logic for `media_player`'s is inverted**. Instead of comparing with the `on` state, for `media_players` it should be 'different from the `off` state', because of the multiple 'active' options that normally a media player presents.

### Example customize config in Home Assistant:
```yaml
homeassistant:
  customize:
    media_player.kodi:
      homebridge_media_player_switch: on_off
```

This change fixes #171 and eliminates the need of extra variables.