### PR TITLE
Remove the need to use NODE_TLS_REJECT_UNAUTHORIZED=0

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ To avoid too much information in your log, just set `logging` to `false` as soon
     "host": "http://127.0.0.1:8123",
     "password": "yourapipassword",
     "supported_types": ["binary_sensor", "climate", "cover", "device_tracker", "fan", "group", "input_boolean", "light", "lock", "media_player", "scene", "sensor", "switch"],
-    "logging": true
+    "logging": true,
+    "verify_ssl": true
   }
 ]
 ```
@@ -129,7 +130,7 @@ You can optionally whitelist the device types that are exposed to HomeKit with t
 
 ### Using with self signed SSL certificates
 
-If you have set up SSL using a self signed certificate, you will need to start Homebridge after running `export NODE_TLS_REJECT_UNAUTHORIZED=0` to allow bypassing the Node.js certificate checks.
+If you have set up SSL using a self signed certificate, you will need to to set `verify_ssl` to `false` in your `config.json` file to allow bypassing the Node.js certificate checks.
 
 ## Customization
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function HomeAssistantPlatform(log, config, api) {
   this.supportedTypes = config.supported_types || ['binary_sensor', 'climate', 'cover', 'device_tracker', 'fan', 'group', 'input_boolean', 'light', 'lock', 'media_player', 'scene', 'sensor', 'switch'];
   this.foundAccessories = [];
   this.logging = config.logging !== undefined ? config.logging : true;
+  this.verify_ssl = config.verify_ssl !== undefined ? config.verify_ssl : true;
 
   this.log = log;
 
@@ -77,6 +78,7 @@ HomeAssistantPlatform.prototype = {
         'Content-Type': 'application/json',
         'x-ha-access': this.password,
       },
+      rejectUnauthorized: this.verify_ssl,
     };
 
     request(reqOpts, (error, response, body) => {


### PR DESCRIPTION
This pull request will allow a self signed certificate on the Home Assistant server without needing to use `NODE_TLS_REJECT_UNAUTHORIZED=0`.

Using `NODE_TLS_REJECT_UNAUTHORIZED=0` also stops TLS verification checks for every other plugin that is enabled in the user's Homebridge config, even those making connections out to the internet, which makes using this approach very insecure.

This change allows TLS verification checks to be disabled via the `config.json` file specifically for this plugin.

```
"verify_ssl": false
```

TLS checks remain enabled by default for users who do not set the `verify_ssl` option and users who currently use `NODE_TLS_REJECT_UNAUTHORIZED=0` to disable TLS verification can continue to do so.
