### PR TITLE
Fixed exception from undefined unit_of_measurement

### DIFF
--- a/accessories/sensor.js
+++ b/accessories/sensor.js
@@ -104,13 +104,13 @@ function HomeAssistantSensorFactory(log, data, client) {
   } else if (data.attributes.unit_of_measurement === '%' && (data.entity_id.includes('humidity') || data.attributes.homebridge_sensor_type === 'humidity')) {
     service = Service.HumiditySensor;
     characteristic = Characteristic.CurrentRelativeHumidity;
-  } else if (data.attributes.unit_of_measurement.toLowerCase() === 'lux' || data.attributes.homebridge_sensor_type === 'light') {
+  } else if ((typeof data.attributes.unit_of_measurement === 'string' && data.attributes.unit_of_measurement.toLowerCase() === 'lux') || data.attributes.homebridge_sensor_type === 'light') {
     service = Service.LightSensor;
     characteristic = Characteristic.CurrentAmbientLightLevel;
     transformData = function transformData(dataToTransform) { // eslint-disable-line no-shadow
       return Math.max(0.0001, parseFloat(dataToTransform.state));
     };
-  } else if (data.attributes.unit_of_measurement.toLowerCase() === 'ppm' && (data.entity_id.includes('co2') || data.attributes.homebridge_sensor_type === 'co2')) {
+  } else if (typeof data.attributes.unit_of_measurement === 'string' && data.attributes.unit_of_measurement.toLowerCase() === 'ppm' && (data.entity_id.includes('co2') || data.attributes.homebridge_sensor_type === 'co2')) {
     service = Service.CarbonDioxideSensor;
     characteristic = Characteristic.CarbonDioxideLevel;
   } else {


### PR DESCRIPTION
Some sensors do not include a unit of measurement causing an exception since the
`toLowerCase()` doesn't exist. Added a condition to verify it's truly a string
before acting upon it.