### PR TITLE
fix media_player switch

### DIFF
--- a/accessories/media_player.js
+++ b/accessories/media_player.js
@@ -85,7 +85,7 @@ function HomeAssistantMediaPlayer(log, data, client) {
 
 HomeAssistantMediaPlayer.prototype = {
   onEvent(oldState, newState) {
-    const powerState;
+    let powerState;
     if (this.stateLogicCompareWithOn) {
         powerState = newState.state === this.onState;
     } else {
@@ -99,7 +99,7 @@ HomeAssistantMediaPlayer.prototype = {
 
     this.client.fetchState(this.entity_id, (data) => {
       if (data) {
-        const powerState;
+        let powerState;
         if (this.stateLogicCompareWithOn) {
             powerState = newState.state === this.onState;
         } else {

--- a/accessories/media_player.js
+++ b/accessories/media_player.js
@@ -24,6 +24,7 @@ function HomeAssistantMediaPlayer(log, data, client) {
   this.entity_id = data.entity_id;
   this.uuid_base = data.entity_id;
   this.supportedFeatures = data.attributes.supported_features;
+  this.stateLogicCompareWithOn = true;
 
   if (data.attributes && data.attributes.friendly_name) {
     this.name = data.attributes.friendly_name;
@@ -41,6 +42,7 @@ function HomeAssistantMediaPlayer(log, data, client) {
     this.offState = 'off';
     this.onService = 'turn_on';
     this.offService = 'turn_off';
+    this.stateLogicCompareWithOn = false;
   } else if (this.data && this.data.attributes && this.data.attributes.homebridge_media_player_switch === 'play_stop' && supportStop) {
     this.onState = 'playing';
     this.offState = 'idle';
@@ -83,15 +85,26 @@ function HomeAssistantMediaPlayer(log, data, client) {
 
 HomeAssistantMediaPlayer.prototype = {
   onEvent(oldState, newState) {
+    const powerState;
+    if (this.stateLogicCompareWithOn) {
+        powerState = newState.state === this.onState;
+    } else {
+        powerState = newState.state !== this.offState;
+    }
     this.switchService.getCharacteristic(Characteristic.On)
-        .setValue(newState.state !== this.offState, null, 'internal');
+        .setValue(powerState, null, 'internal');
   },
   getPowerState(callback) {
     this.log(`fetching power state for: ${this.name}`);
 
     this.client.fetchState(this.entity_id, (data) => {
       if (data) {
-        const powerState = data.state !== this.offState;
+        const powerState;
+        if (this.stateLogicCompareWithOn) {
+            powerState = newState.state === this.onState;
+        } else {
+            powerState = newState.state !== this.offState;
+        }
         callback(null, powerState);
       } else {
         callback(communicationError);

--- a/accessories/media_player.js
+++ b/accessories/media_player.js
@@ -87,9 +87,9 @@ HomeAssistantMediaPlayer.prototype = {
   onEvent(oldState, newState) {
     let powerState;
     if (this.stateLogicCompareWithOn) {
-        powerState = newState.state === this.onState;
+      powerState = newState.state === this.onState;
     } else {
-        powerState = newState.state !== this.offState;
+      powerState = newState.state !== this.offState;
     }
     this.switchService.getCharacteristic(Characteristic.On)
         .setValue(powerState, null, 'internal');
@@ -101,9 +101,9 @@ HomeAssistantMediaPlayer.prototype = {
       if (data) {
         let powerState;
         if (this.stateLogicCompareWithOn) {
-            powerState = newState.state === this.onState;
+          powerState = data.state === this.onState;
         } else {
-            powerState = newState.state !== this.offState;
+          powerState = data.state !== this.offState;
         }
         callback(null, powerState);
       } else {


### PR DESCRIPTION
Revert to use positive logic (comparing with 'onState') for all media player switch modes except for the explicit `homebridge_media_player_switch` as `on_off`. 
That should revert to the old mode and solve #193.