### PR TITLE
Add support for battery tracking and charging status

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ customize:
 
 If you don't specify the accessory information, the data will be pulled from Home Assistant by default.
 
+## Battery Tracking
+
+Battery tracking is supported for binary sensors, device trackers, locks, and sensors.
+
+`homebridge_battery_source` must be set to an entity with '%' as its unit of measurement.
+
+`homebridge_charging_source` must set to an entity with `charging` as one of its possible states.
+
+If `homebridge_battery_source` is specified but `homebridge_charging_source` is not, then HomeKit will consider the battery as not chargeable.
+
+If necessary, you can create template sensors within Home Assistant to use for `homebridge_battery_source` and `homebridge_charging_source`.
+
 ## Contributions
 
 * fork

--- a/accessories/binary_sensor.js
+++ b/accessories/binary_sensor.js
@@ -41,6 +41,8 @@ class HomeAssistantBinarySensor {
     this.characteristic = characteristic;
     this.onValue = onValue;
     this.offValue = offValue;
+    this.batterySource = data.attributes.homebridge_battery_source;
+    this.chargingSource = data.attributes.homebridge_charging_source;
   }
 
   onEvent(oldState, newState) {
@@ -61,6 +63,37 @@ class HomeAssistantBinarySensor {
       }
     });
   }
+  getBatteryLevel(callback) {
+    this.client.fetchState(this.batterySource, (data) => {
+      if (data) {
+        callback(null, parseFloat(data.state));
+      } else {
+        callback(communicationError);
+      }
+    });
+  }
+  getChargingState(callback) {
+    if (this.batterySource && this.chargingSource) {
+      this.client.fetchState(this.chargingSource, (data) => {
+        if (data) {
+          callback(null, data.state.toLowerCase() === 'charging' ? 1 : 0);
+        } else {
+          callback(communicationError);
+        }
+      });
+    } else {
+      callback(null, 2);
+    }
+  }
+  getLowBatteryStatus(callback) {
+    this.client.fetchState(this.batterySource, (data) => {
+      if (data) {
+        callback(null, parseFloat(data.state) > 20 ? 0 : 1);
+      } else {
+        callback(communicationError);
+      }
+    });
+  }
   getServices() {
     this.sensorService = new this.service(); // eslint-disable-line new-cap
     this.sensorService
@@ -74,6 +107,21 @@ class HomeAssistantBinarySensor {
           .setCharacteristic(Characteristic.Model, this.model)
           .setCharacteristic(Characteristic.SerialNumber, this.serial);
 
+    if (this.batterySource) {
+      this.batteryService = new Service.BatteryService();
+      this.batteryService
+        .getCharacteristic(Characteristic.BatteryLevel)
+        .setProps({ maxValue: 100, minValue: 0, minStep: 1 })
+        .on('get', this.getBatteryLevel.bind(this));
+      this.batteryService
+        .getCharacteristic(Characteristic.ChargingState)
+        .setProps({ maxValue: 2 })
+        .on('get', this.getChargingState.bind(this));
+      this.batteryService
+        .getCharacteristic(Characteristic.StatusLowBattery)
+        .on('get', this.getLowBatteryStatus.bind(this));
+      return [informationService, this.batteryService, this.sensorService];
+    }
     return [informationService, this.sensorService];
   }
 }


### PR DESCRIPTION
- Applicable to binary sensors, device trackers, locks, and sensors for now (additional device types can be added in the future)
- See updated README for usage instructions
- Verified with iOS 10 Home app (not all HomeKit apps may support this)