### PR TITLE
Add support for identifying lights during setup

### DIFF
--- a/accessories/light.js
+++ b/accessories/light.js
@@ -169,9 +169,12 @@ HomeAssistantLight.prototype = {
     const that = this;
     const serviceData = {};
     serviceData.entity_id = this.entity_id;
-    serviceData.flash = 'short';
-
-    this.client.callService(this.domain, 'turn_on', serviceData, (data) => {
+    let service = 'toggle';
+    if (this.is_supported(this.features.FLASH)) {
+      service = 'turn_on';
+      serviceData.flash = 'short';
+    }
+    this.client.callService(this.domain, service, serviceData, (data) => {
       if (data) {
         that.log(`Successfully identified '${that.name}'`);
       }
@@ -377,6 +380,10 @@ HomeAssistantLight.prototype = {
           .setCharacteristic(Characteristic.Manufacturer, this.mfg)
           .setCharacteristic(Characteristic.Model, this.model)
           .setCharacteristic(Characteristic.SerialNumber, this.serial);
+
+    informationService
+          .setCharacteristic(Characteristic.Identify)
+          .on('set', this.identify.bind(this));
 
     this.lightbulbService
           .getCharacteristic(Characteristic.On)


### PR DESCRIPTION
- When setting up Homebridge for the first time in iOS Home app, you're presented with the Identify button (see below).
- Previously, pressing this button did nothing.
- Now, pressing this button will either flash the light (if supported) or toggle between on and off.

![img_0995](https://user-images.githubusercontent.com/630673/29243477-edde1d86-7f6d-11e7-800d-18be02eef9f7.PNG)

