### PR TITLE
Set default value for 'default_visibility'

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ If you have set up SSL using a self signed certificate, you will need to to set 
 
 ## Customization
 
-To control which entities are passed to Homebridge, you must specify `default_visibility` to `hidden` or `visible`.
+To control which entities are passed to Homebridge, you can set `default_visibility` to `hidden` or `visible`.
+
+If not specified, `default_visibility` will be set to `visible`.
 
 Then, you can control individual entities within Home Assistant using `homebridge_hidden` or `homebridge_visible`.
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ function HomeAssistantPlatform(log, config, api) {
   if (config.default_visibility === 'hidden' || config.default_visibility === 'visible') {
     this.defaultVisibility = config.default_visibility;
   } else {
+    this.defaultVisibility = 'visible';
     this.log.error('Please set default_visibility in config.json to "hidden" or "visible".');
   }
 


### PR DESCRIPTION
- If not specified, `default_visibility` will be set to `visible` (similar to previous behavior)
- Update README.md with more detail
- Fixes #212 