### PR TITLE
Properly display Fahrenheit temperatures for climate accessories

### DIFF
--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -2,6 +2,16 @@ var Service;
 var Characteristic;
 var communicationError;
 
+
+function fahrenheitToCelsius(temperature) {
+    return (temperature - 32) / 1.8;
+}
+ 
+function celsiusToFahrenheit(temperature) {
+    return (temperature * 1.8) + 32;
+}
+
+
 function HomeAssistantClimate(log, data, client) {
     // device info
 
@@ -160,19 +170,40 @@ HomeAssistantClimate.prototype = {
           .getCharacteristic(Characteristic.CurrentTemperature)
           .on('get', this.getCurrentTemp.bind(this));
 
+    // default min/max/step for temperature
     var minTemp = 7.0;
     var maxTemp = 35.0;
     var tempStep = 0.5;
+    // get our unit var -- default to celsius
+    var units = Characteristic.TemperatureDisplayUnits.CELSIUS
+    if (this.data && this.data.attributes && this.data.attributes.unit_of_measurement) {
+      var units = (this.data.attributes.unit_of_measurement === '°F') ? Characteristic.TemperatureDisplayUnits.FAHRENHEIT : Characteristic.TemperatureDisplayUnits.CELSIUS;
+    }
+    this.ThermostatService.setCharacteristic(Characteristic.TemperatureDisplayUnits, units);
 
-    if (this.data && this.data.attributes) {
-      if (this.data.attributes.min_temp) {
-        minTemp = this.data.attributes.min_temp;
+    if (units == Characteristic.TemperatureDisplayUnits.FAHRENHEIT) {
+      if (this.data && this.data.attributes) {
+        if (this.data.attributes.min_temp) {
+          minTemp = fahrenheitToCelsius(this.data.attributes.min_temp);
+        }
+        if (this.data.attributes.max_temp) {
+          maxTemp = fahrenheitToCelsius(this.data.attributes.max_temp);
+        }
+        if (this.data.attributes.target_temp_step) {
+          tempStep = this.data.attributes.target_temp_step;
+        }
       }
-      if (this.data.attributes.max_temp) {
-        maxTemp = this.data.attributes.max_temp;
-      }
-      if (this.data.attributes.target_temp_step) {
-        tempStep = this.data.attributes.target_temp_step;
+    } else {
+      if (this.data && this.data.attributes) {
+        if (this.data.attributes.min_temp) {
+          minTemp = this.data.attributes.min_temp;
+        }
+        if (this.data.attributes.max_temp) {
+          maxTemp = this.data.attributes.max_temp;
+        }
+        if (this.data.attributes.target_temp_step) {
+          tempStep = this.data.attributes.target_temp_step;
+        }
       }
     }
 

--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -52,14 +52,14 @@ HomeAssistantClimate.prototype = {
   getCurrentTemp: function (callback) {
     this.client.fetchState(this.entity_id, function (data) {
       if (data) {
-        callback(null, data.attributes.current_temperature);
+        callback(null, data.attributes.current_temperature); // may need conversion?
       } else {
         callback(communicationError);
       }
     });
   },
   getTargetTemp: function (callback) {
-    this.client.fetchState(this.entity_id, function (data) {
+    this.client.fetchState(this.entity_id, function (data) { // may need conversion?
       if (data) {
         callback(null, data.attributes.temperature);
       } else {
@@ -166,6 +166,14 @@ HomeAssistantClimate.prototype = {
           .setCharacteristic(Characteristic.Model, this.model)
           .setCharacteristic(Characteristic.SerialNumber, this.serial);
 
+    // get our unit var -- default to celsius
+    var units = Characteristic.TemperatureDisplayUnits.CELSIUS
+    if (this.data && this.data.attributes && this.data.attributes.unit_of_measurement) {
+      var units = (this.data.attributes.unit_of_measurement === '°F') ? Characteristic.TemperatureDisplayUnits.FAHRENHEIT : Characteristic.TemperatureDisplayUnits.CELSIUS;
+    }
+    this.ThermostatService.setCharacteristic(Characteristic.TemperatureDisplayUnits, units);
+
+
     this.ThermostatService
           .getCharacteristic(Characteristic.CurrentTemperature)
           .on('get', this.getCurrentTemp.bind(this));
@@ -174,12 +182,6 @@ HomeAssistantClimate.prototype = {
     var minTemp = 7.0;
     var maxTemp = 35.0;
     var tempStep = 0.5;
-    // get our unit var -- default to celsius
-    var units = Characteristic.TemperatureDisplayUnits.CELSIUS
-    if (this.data && this.data.attributes && this.data.attributes.unit_of_measurement) {
-      var units = (this.data.attributes.unit_of_measurement === '°F') ? Characteristic.TemperatureDisplayUnits.FAHRENHEIT : Characteristic.TemperatureDisplayUnits.CELSIUS;
-    }
-    this.ThermostatService.setCharacteristic(Characteristic.TemperatureDisplayUnits, units);
 
     if (units == Characteristic.TemperatureDisplayUnits.FAHRENHEIT) {
       if (this.data && this.data.attributes) {


### PR DESCRIPTION
Attempting to deal with #222. See that issue for an explanation of my thought process.

To reiterate briefly, the problem seems to be that the Home app expects temperatures in celsius, and depending on the `TemperatureDisplayUnits` characteristic will convert to Fahrenheit or simply display the celsius temperature. So the main changes here are converting the temperature back to celsius (if it comes from HomeAssistant in fahrenheit) before passing it to Home with the correct `TemperatureDisplayUnits` set.