### PR TITLE
Fan uses speed list from home-assistant and supports equal increment between speed

### DIFF
--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -118,24 +118,36 @@ HomeAssistantFan.prototype = {
     const serviceData = {};
     serviceData.entity_id = this.entity_id;
 
-    if (speed <= 25) {
-      serviceData.speed = 'low';
-    } else if (speed <= 75) {
-      serviceData.speed = 'medium';
-    } else if (speed <= 100) {
-      serviceData.speed = 'high';
-    }
+    if (speed == 0) {
+        this.log(`Setting power state on the '${this.name}' to off`);
 
-    this.log(`Setting speed on the '${this.name}' to ${serviceData.speed}`);
+        this.client.callService(this.domain, 'turn_off', serviceData, (data) => {
+          if (data) {
+            that.log(`Successfully set power state on the '${that.name}' to off`);
+            callback();
+          } else {
+            callback(communicationError);
+          }
+        });
+    } else {
+		if (speed <= 25) {
+	      serviceData.speed = 'low';
+	    } else if (speed <= 75) {
+	      serviceData.speed = 'medium';
+	    } else if (speed <= 100) {
+	      serviceData.speed = 'high';
+	    }
+	    this.log(`Setting speed on the '${this.name}' to ${serviceData.speed}`);
 
-    this.client.callService(this.domain, 'set_speed', serviceData, (data) => {
-      if (data) {
-        that.log(`Successfully set power state on the '${that.name}' to on`);
-        callback();
-      } else {
-        callback(communicationError);
-      }
-    });
+	    this.client.callService(this.domain, 'set_speed', serviceData, (data) => {
+	      if (data) {
+	        that.log(`Successfully set power state on the '${that.name}' to on`);
+	        callback();
+	      } else {
+	        callback(communicationError);
+	      }
+	    });
+	}
   },
   getServices() {
     this.fanService = new Service.Fan();

--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -32,6 +32,10 @@ function HomeAssistantFan(log, data, client) {
   }
   this.client = client;
   this.log = log;
+  
+  var speed_list = data.attributes.speed_list;
+  var increment = Math.round(100.0 / (speed_list.length - 1));
+  this.increment = increment;
 }
 
 HomeAssistantFan.prototype = {
@@ -105,8 +109,7 @@ HomeAssistantFan.prototype = {
     				  else {
     					  var index = speed_list.indexOf(speed);
     					  if (index != -1) {
-    						  var increment = Math.round(100.0 / (speed_list.length - 1));
-    						  var value = increment * index;
+    						  var value = this.increment * index;
     						  callback(null, value);
     					  }
     					  else {
@@ -166,9 +169,8 @@ HomeAssistantFan.prototype = {
 						serviceData.speed = speed_list[speed_list.length-1];
 					}
 					else {
-						var increment = Math.round(100.0 / (speed_list.length - 1));
 						for (var index = 1; index < speed_list.length-1; index += 1) {
-							var value = increment * index;
+							var value = this.increment * index;
 							if (speed <= value) {
 								serviceData.speed = speed_list[index];
 								break;
@@ -221,6 +223,11 @@ HomeAssistantFan.prototype = {
 
     this.fanService
         .getCharacteristic(Characteristic.RotationSpeed)
+		.setProps({
+			minValue: 0,
+			maxValue: 100,
+			minStep: this.increment,
+		})
         .on('get', this.getRotationSpeed.bind(this))
         .on('set', this.setRotationSpeed.bind(this));
 

--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -34,8 +34,7 @@ function HomeAssistantFan(log, data, client) {
   this.log = log;
   
   var speed_list = data.attributes.speed_list;
-  var increment = Math.round(100.0 / (speed_list.length - 1));
-  this.increment = increment;
+  this.maxValue = speed_list.length-1;
 }
 
 HomeAssistantFan.prototype = {
@@ -96,26 +95,10 @@ HomeAssistantFan.prototype = {
     		  var speed_list = data.attributes.speed_list;
     		  if (speed_list) {
     			  if (speed_list.length > 2) {
-    		          var lowest = speed_list[0];
-    				  var highest = speed_list[speed_list.length-1];
-			  
-    				  var speed = data.attributes.speed;
-    				  if (speed == lowest) {
-    				  	 callback(null, 0);
-    				  }
-    				  else if (speed == highest) {
-    				  	 callback(null, 100);
-    				  }
-    				  else {
-    					  var index = speed_list.indexOf(speed);
-    					  if (index != -1) {
-    						  var value = this.increment * index;
-    						  callback(null, value);
-    					  }
-    					  else {
-    						  callback(null, 0);
-    					  }
-    				  }
+					  
+					  var speed = data.attributes.speed;
+					  var index = speed_list.indexOf(speed);
+					  callback(null, index);
     			  }
     		  }
     		  else {
@@ -165,20 +148,14 @@ HomeAssistantFan.prototype = {
 			if (data) {
 				var speed_list = data.attributes.speed_list;
 				if (speed_list) {
-					if (speed == 100) {
-						serviceData.speed = speed_list[speed_list.length-1];
+					for (var index = 0; index < speed_list.length-1; index += 1) {
+						if (speed == index) {
+							serviceData.speed = speed_list[index];
+							break;
+						}
 					}
-					else {
-						for (var index = 1; index < speed_list.length-1; index += 1) {
-							var value = this.increment * index;
-							if (speed <= value) {
-								serviceData.speed = speed_list[index];
-								break;
-							}
-						}
-						if (!serviceData.speed) {
-							serviceData.speed = speed_list[speed_list.length-1];
-						}
+					if (!serviceData.speed) {
+						serviceData.speed = speed_list[speed_list.length-1];
 					}
 				}
 				else {
@@ -225,8 +202,8 @@ HomeAssistantFan.prototype = {
         .getCharacteristic(Characteristic.RotationSpeed)
 		.setProps({
 			minValue: 0,
-			maxValue: 100,
-			minStep: this.increment,
+			maxValue: this.maxValue,
+			minStep: 1
 		})
         .on('get', this.getRotationSpeed.bind(this))
         .on('set', this.setRotationSpeed.bind(this));

--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -90,42 +90,46 @@ HomeAssistantFan.prototype = {
           callback(null, 0);
         } else {
 		  var speed_list = data.attributes.speed_list;
-		  if (speed_list.length > 2) {
-	          var lowest = speed_list[0];
-			  var highest = speed_list[speed_list.length-1];
+		  if (speed_list) {
+			  if (speed_list.length > 2) {
+		          var lowest = speed_list[0];
+				  var highest = speed_list[speed_list.length-1];
 			  
-			  var speed = data.attributes.speed;
-			  if (speed == lowest) {
-			  	 callback(null, 0);
-			  }
-			  else if (speed == highest) {
-			  	 callback(null, 100);
-			  }
-			  else {
-				  var index = speed_list.indexOf(speed);
-				  if (index != -1) {
-					  var increment = Math.round(100.0 / (speed_list.length - 1));
-					  var value = increment * index;
-					  callback(null, value);
+				  var speed = data.attributes.speed;
+				  if (speed == lowest) {
+				  	 callback(null, 0);
+				  }
+				  else if (speed == highest) {
+				  	 callback(null, 100);
 				  }
 				  else {
-					  callback(null, 0);
+					  var index = speed_list.indexOf(speed);
+					  if (index != -1) {
+						  var increment = Math.round(100.0 / (speed_list.length - 1));
+						  var value = increment * index;
+						  callback(null, value);
+					  }
+					  else {
+						  callback(null, 0);
+					  }
 				  }
 			  }
 		  }
-          // switch (data.attributes.speed) {
-//             case 'low':
-//               callback(null, 25);
-//               break;
-//             case 'medium':
-//               callback(null, 50);
-//               break;
-//             case 'high':
-//               callback(null, 100);
-//               break;
-//             default:
-//               callback(null, 0);
-//           }
+		  else {
+	          switch (data.attributes.speed) {
+	            case 'low':
+	              callback(null, 25);
+	              break;
+	            case 'medium':
+	              callback(null, 50);
+	              break;
+	            case 'high':
+	              callback(null, 100);
+	              break;
+	            default:
+	              callback(null, 0);
+	          }
+		  }
         }
       } else {
         callback(communicationError);
@@ -157,32 +161,33 @@ HomeAssistantFan.prototype = {
 		this.client.fetchState(this.entity_id, (data) => {
 			if (data) {
 				var speed_list = data.attributes.speed_list;
-				if (speed == 100) {
-					serviceData.speed = speed_list[speed_list.length-1];
-				}
-				else {
-					this.log(`speed ${speed}`);
-					var increment = Math.round(100.0 / (speed_list.length - 1));
-					this.log(`increment ${increment}`);
-					for (var index = 1; index < speed_list.length-1; index += 1) {
-						var value = increment * index;
-						this.log(`compare ${speed} with ${value}`);
-						if (speed <= value) {
-							serviceData.speed = speed_list[index];
-							break;
-						}
-					}
-					if (!serviceData.speed) {
+				if (speed_list) {
+					if (speed == 100) {
 						serviceData.speed = speed_list[speed_list.length-1];
 					}
+					else {
+						var increment = Math.round(100.0 / (speed_list.length - 1));
+						for (var index = 1; index < speed_list.length-1; index += 1) {
+							var value = increment * index;
+							if (speed <= value) {
+								serviceData.speed = speed_list[index];
+								break;
+							}
+						}
+						if (!serviceData.speed) {
+							serviceData.speed = speed_list[speed_list.length-1];
+						}
+					}
 				}
-				// if (speed <= 25) {
-// 			      serviceData.speed = 'low';
-// 			    } else if (speed <= 75) {
-// 			      serviceData.speed = 'medium';
-// 			    } else if (speed <= 100) {
-// 			      serviceData.speed = 'high';
-// 			    }
+				else {
+					if (speed <= 25) {
+				      serviceData.speed = 'low';
+				    } else if (speed <= 75) {
+				      serviceData.speed = 'medium';
+				    } else if (speed <= 100) {
+				      serviceData.speed = 'high';
+				    }
+				}
 			    this.log(`Setting speed on the '${this.name}' to ${serviceData.speed}`);
 
 			    this.client.callService(this.domain, 'set_speed', serviceData, (data) => {

--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -97,33 +97,32 @@ HomeAssistantFan.prototype = {
           if (data.state === 'off') {
             callback(null, 0);
           } else {
-    		  var speed_list = data.attributes.speed_list;
-    		  if (speed_list) {
-    			  if (speed_list.length > 2) {
-					  
-					  var speed = data.attributes.speed;
-					  var index = speed_list.indexOf(speed);
-					  callback(null, index);
-    			  }
-    		  }
-    		  else {
-    	          switch (data.attributes.speed) {
-    	            case 'low':
-    	              callback(null, 25);
-    	              break;
-    	            case 'medium':
-    	              callback(null, 50);
-    	              break;
-    	            case 'high':
-    	              callback(null, 100);
-    	              break;
-    	            default:
-    	              callback(null, 0);
-    	          }
-    		  }
-          }
-      } else {
-		  callback(communicationError);
+			var speed_list = data.attributes.speed_list;
+			if (speed_list) {
+			  if (speed_list.length > 2) {
+				var speed = data.attributes.speed;
+				var index = speed_list.indexOf(speed);
+				callback(null, index);
+			  }
+		  	}
+			else {
+			  switch (data.attributes.speed) {
+			    case 'low':
+				  callback(null, 25);
+				  break;
+			    case 'medium':
+				  callback(null, 50);
+				  break;
+			    case 'high':
+				  callback(null, 100);
+				  break;
+			    default:
+				  callback(null, 0);
+    	      }
+		    }
+		  }
+	  } else {
+		callback(communicationError);
       }
     });
   },
@@ -151,40 +150,40 @@ HomeAssistantFan.prototype = {
     } else {
 		this.client.fetchState(this.entity_id, (data) => {
 			if (data) {
-				var speed_list = data.attributes.speed_list;
-				if (speed_list) {
-					for (var index = 0; index < speed_list.length-1; index += 1) {
-						if (speed == index) {
-							serviceData.speed = speed_list[index];
-							break;
-						}
-					}
-					if (!serviceData.speed) {
-						serviceData.speed = speed_list[speed_list.length-1];
-					}
+			  var speed_list = data.attributes.speed_list;
+			  if (speed_list) {
+				for (var index = 0; index < speed_list.length-1; index += 1) {
+				  if (speed == index) {
+					serviceData.speed = speed_list[index];
+					break;
+				  }
 				}
-				else {
-					if (speed <= 25) {
-				      serviceData.speed = 'low';
-				    } else if (speed <= 75) {
-				      serviceData.speed = 'medium';
-				    } else if (speed <= 100) {
-				      serviceData.speed = 'high';
-				    }
+				if (!serviceData.speed) {
+				  serviceData.speed = speed_list[speed_list.length-1];
 				}
-			    this.log(`Setting speed on the '${this.name}' to ${serviceData.speed}`);
-
-			    this.client.callService(this.domain, 'set_speed', serviceData, (data) => {
-			      if (data) {
-			        that.log(`Successfully set power state on the '${that.name}' to on`);
-			        callback();
-			      } else {
-			        callback(communicationError);
-			      }
-			    });
+			  }
+			  else {
+				if (speed <= 25) {
+				  serviceData.speed = 'low';
+				} else if (speed <= 75) {
+				  serviceData.speed = 'medium';
+				} else if (speed <= 100) {
+				  serviceData.speed = 'high';
+				}
+			  }
+			  this.log(`Setting speed on the '${this.name}' to ${serviceData.speed}`);
+			  
+			  this.client.callService(this.domain, 'set_speed', serviceData, (data) => {
+				if (data) {
+			      that.log(`Successfully set power state on the '${that.name}' to on`);
+			      callback();
+			    } else {
+			      callback(communicationError);
+			    }
+			  });
 			}
 			else {
-				callback(communicationError);
+			  callback(communicationError);
 			}
 		});
 	}

--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -34,7 +34,12 @@ function HomeAssistantFan(log, data, client) {
   this.log = log;
   
   var speed_list = data.attributes.speed_list;
-  this.maxValue = speed_list.length-1;
+  if (speed_list) {
+	  this.maxValue = speed_list.length-1;
+  }
+  else {
+	  this.maxValue = 100;
+  }
 }
 
 HomeAssistantFan.prototype = {

--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -86,53 +86,53 @@ HomeAssistantFan.prototype = {
   getRotationSpeed(callback) {
     this.client.fetchState(this.entity_id, (data) => {
       if (data) {
-        if (data.state === 'off') {
-          callback(null, 0);
-        } else {
-		  var speed_list = data.attributes.speed_list;
-		  if (speed_list) {
-			  if (speed_list.length > 2) {
-		          var lowest = speed_list[0];
-				  var highest = speed_list[speed_list.length-1];
+          if (data.state === 'off') {
+            callback(null, 0);
+          } else {
+    		  var speed_list = data.attributes.speed_list;
+    		  if (speed_list) {
+    			  if (speed_list.length > 2) {
+    		          var lowest = speed_list[0];
+    				  var highest = speed_list[speed_list.length-1];
 			  
-				  var speed = data.attributes.speed;
-				  if (speed == lowest) {
-				  	 callback(null, 0);
-				  }
-				  else if (speed == highest) {
-				  	 callback(null, 100);
-				  }
-				  else {
-					  var index = speed_list.indexOf(speed);
-					  if (index != -1) {
-						  var increment = Math.round(100.0 / (speed_list.length - 1));
-						  var value = increment * index;
-						  callback(null, value);
-					  }
-					  else {
-						  callback(null, 0);
-					  }
-				  }
-			  }
-		  }
-		  else {
-	          switch (data.attributes.speed) {
-	            case 'low':
-	              callback(null, 25);
-	              break;
-	            case 'medium':
-	              callback(null, 50);
-	              break;
-	            case 'high':
-	              callback(null, 100);
-	              break;
-	            default:
-	              callback(null, 0);
-	          }
-		  }
-        }
+    				  var speed = data.attributes.speed;
+    				  if (speed == lowest) {
+    				  	 callback(null, 0);
+    				  }
+    				  else if (speed == highest) {
+    				  	 callback(null, 100);
+    				  }
+    				  else {
+    					  var index = speed_list.indexOf(speed);
+    					  if (index != -1) {
+    						  var increment = Math.round(100.0 / (speed_list.length - 1));
+    						  var value = increment * index;
+    						  callback(null, value);
+    					  }
+    					  else {
+    						  callback(null, 0);
+    					  }
+    				  }
+    			  }
+    		  }
+    		  else {
+    	          switch (data.attributes.speed) {
+    	            case 'low':
+    	              callback(null, 25);
+    	              break;
+    	            case 'medium':
+    	              callback(null, 50);
+    	              break;
+    	            case 'high':
+    	              callback(null, 100);
+    	              break;
+    	            default:
+    	              callback(null, 0);
+    	          }
+    		  }
+          }
       } else {
-        callback(communicationError);
+		  callback(communicationError);
       }
     });
   },

--- a/accessories/fan.js
+++ b/accessories/fan.js
@@ -35,10 +35,10 @@ function HomeAssistantFan(log, data, client) {
   
   var speed_list = data.attributes.speed_list;
   if (speed_list) {
-	  this.maxValue = speed_list.length-1;
+    this.maxValue = speed_list.length-1;
   }
   else {
-	  this.maxValue = 100;
+    this.maxValue = 100;
   }
 }
 
@@ -94,37 +94,36 @@ HomeAssistantFan.prototype = {
   getRotationSpeed(callback) {
     this.client.fetchState(this.entity_id, (data) => {
       if (data) {
-          if (data.state === 'off') {
-            callback(null, 0);
+        if (data.state === 'off') {
+          callback(null, 0);
+        } else {
+          var speed_list = data.attributes.speed_list;
+          if (speed_list) {
+            if (speed_list.length > 2) {
+              var speed = data.attributes.speed;
+              var index = speed_list.indexOf(speed);
+              callback(null, index);
+            }
           } else {
-			var speed_list = data.attributes.speed_list;
-			if (speed_list) {
-			  if (speed_list.length > 2) {
-				var speed = data.attributes.speed;
-				var index = speed_list.indexOf(speed);
-				callback(null, index);
-			  }
-		  	}
-			else {
-			  switch (data.attributes.speed) {
-			    case 'low':
-				  callback(null, 25);
-				  break;
-			    case 'medium':
-				  callback(null, 50);
-				  break;
-			    case 'high':
-				  callback(null, 100);
-				  break;
-			    default:
-				  callback(null, 0);
-    	      }
-		    }
-		  }
-	  } else {
-		callback(communicationError);
-      }
-    });
+            switch (data.attributes.speed) {
+              case 'low':
+                callback(null, 25);
+                break;
+              case 'medium':
+                callback(null, 50);
+                break;
+              case 'high':
+                callback(null, 100);
+                break;
+              default:
+                callback(null, 0);
+              }
+            }
+          }
+        } else {
+          callback(communicationError);
+        }
+      });
   },
   setRotationSpeed(speed, callback, context) {
     if (context === 'internal') {
@@ -137,56 +136,54 @@ HomeAssistantFan.prototype = {
     serviceData.entity_id = this.entity_id;
 
     if (speed == 0) {
-        this.log(`Setting power state on the '${this.name}' to off`);
+      this.log(`Setting power state on the '${this.name}' to off`);
 
-        this.client.callService(this.domain, 'turn_off', serviceData, (data) => {
-          if (data) {
-            that.log(`Successfully set power state on the '${that.name}' to off`);
-            callback();
-          } else {
-            callback(communicationError);
-          }
-        });
+      this.client.callService(this.domain, 'turn_off', serviceData, (data) => {
+        if (data) {
+          that.log(`Successfully set power state on the '${that.name}' to off`);
+          callback();
+        } else {
+          callback(communicationError);
+        }
+      });
     } else {
-		this.client.fetchState(this.entity_id, (data) => {
-			if (data) {
-			  var speed_list = data.attributes.speed_list;
-			  if (speed_list) {
-				for (var index = 0; index < speed_list.length-1; index += 1) {
-				  if (speed == index) {
-					serviceData.speed = speed_list[index];
-					break;
-				  }
-				}
-				if (!serviceData.speed) {
-				  serviceData.speed = speed_list[speed_list.length-1];
-				}
-			  }
-			  else {
-				if (speed <= 25) {
-				  serviceData.speed = 'low';
-				} else if (speed <= 75) {
-				  serviceData.speed = 'medium';
-				} else if (speed <= 100) {
-				  serviceData.speed = 'high';
-				}
-			  }
-			  this.log(`Setting speed on the '${this.name}' to ${serviceData.speed}`);
-			  
-			  this.client.callService(this.domain, 'set_speed', serviceData, (data) => {
-				if (data) {
-			      that.log(`Successfully set power state on the '${that.name}' to on`);
-			      callback();
-			    } else {
-			      callback(communicationError);
-			    }
-			  });
-			}
-			else {
-			  callback(communicationError);
-			}
-		});
-	}
+  		this.client.fetchState(this.entity_id, (data) => {
+        if (data) {
+          var speed_list = data.attributes.speed_list;
+          if (speed_list) {
+            for (var index = 0; index < speed_list.length-1; index += 1) {
+              if (speed == index) {
+                serviceData.speed = speed_list[index];
+                break;
+              }
+            }
+            if (!serviceData.speed) {
+              serviceData.speed = speed_list[speed_list.length-1];
+            }
+          } else {
+            if (speed <= 25) {
+              serviceData.speed = 'low';
+            } else if (speed <= 75) {
+              serviceData.speed = 'medium';
+            } else if (speed <= 100) {
+              serviceData.speed = 'high';
+            }
+          }
+          this.log(`Setting speed on the '${this.name}' to ${serviceData.speed}`);
+          
+          this.client.callService(this.domain, 'set_speed', serviceData, (data) => {
+            if (data) {
+              that.log(`Successfully set power state on the '${that.name}' to on`);
+              callback();
+            } else {
+              callback(communicationError);
+            }
+          });
+        } else {
+          callback(communicationError);
+        }
+      });
+    }
   },
   getServices() {
     this.fanService = new Service.Fan();
@@ -204,11 +201,11 @@ HomeAssistantFan.prototype = {
 
     this.fanService
         .getCharacteristic(Characteristic.RotationSpeed)
-		.setProps({
-			minValue: 0,
-			maxValue: this.maxValue,
-			minStep: 1
-		})
+        .setProps({
+          minValue: 0,
+          maxValue: this.maxValue,
+          minStep: 1
+        })
         .on('get', this.getRotationSpeed.bind(this))
         .on('set', this.setRotationSpeed.bind(this));
 


### PR DESCRIPTION
This update fetches speed_list from home-assistant, so it can support fan that has more than 3 speed (existing implementation hardcodes low, medium and high). 

It also provides equal increment between speed with the HomeKit speed slider. For example if the available speed are low, medium and high, the slider can automatically snap to 33% when trying to adjust to low. 

I’m not familiar with js, so I’m not sure why my file spacing seems to have issue after committing. Will be happy to fix that if someone can point out how I can do it. Thanks. 