### PR TITLE
fixing climate platform current temperature display

### DIFF
--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -59,9 +59,9 @@ HomeAssistantClimate.prototype = {
     this.client.fetchState(this.entity_id, function (data) {
       if (data) {
         if (getTempUnits(data) === 'FAHRENHEIT') {
-          callback(null, fahrenheitToCelsius(data.attributes.temperature));
+          callback(null, fahrenheitToCelsius(data.attributes.current_temperature));
         } else {
-          callback(null, data.attributes.temperature);
+          callback(null, data.attributes.current_temperature);
         }
       } else {
         callback(communicationError);


### PR DESCRIPTION
[A user](https://community.home-assistant.io/t/fahrenheit-temperatures-for-climate-accessories/29877/6) brought up that the current temperature value in homekit/home app was incorrectly displayed as the same value as the target temperature.

Looks like a simple fix: `getCurrentTemp` is accessing the `temperature` data attribute from HomeAssistant rather than the `current_temperature` data attribute.