### PR TITLE
Changed climate accessory to set operation state to off as per conven…

### DIFF
--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -119,7 +119,7 @@ HomeAssistantClimate.prototype = {
           case 'heat':
             state = Characteristic.TargetHeatingCoolingState.HEAT;
             break;
-          case 'idle':
+          case 'off':
           default:
             state = Characteristic.TargetHeatingCoolingState.OFF;
             break;
@@ -152,7 +152,7 @@ HomeAssistantClimate.prototype = {
         break;
       case Characteristic.TargetHeatingCoolingState.OFF:
       default:
-        mode = 'idle';
+        mode = 'off';
         break;
     }
 


### PR DESCRIPTION
…tion in homeassistant

Currently home bridge uses the 'idle' state when turning off a climate device. However it seems like the IDLE state is different from "off", and in fact many climate devices in Homebridge use STATE_OFF to denote off..

