### PR TITLE
Changed climate accessory to set operation state to off as per conven…

### DIFF
--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -119,7 +119,7 @@ HomeAssistantClimate.prototype = {
           case 'heat':
             state = Characteristic.TargetHeatingCoolingState.HEAT;
             break;
-          case 'idle':
+          case 'off':
           default:
             state = Characteristic.TargetHeatingCoolingState.OFF;
             break;
@@ -152,7 +152,7 @@ HomeAssistantClimate.prototype = {
         break;
       case Characteristic.TargetHeatingCoolingState.OFF:
       default:
-        mode = 'idle';
+        mode = 'off';
         break;
     }
 


### PR DESCRIPTION
…tion in homeassistant


In homeassistant, STATE_OFF is typically used to turn off climate control systems, and state idle is to set them to idle (e.g standby). This branch makes homebridge-homeassistant issue an "off" request rather than "idle" request for turning off climate control devices.