### PR TITLE
Support Celsius and Fahrenheit characters as units

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Air quality, carbon dioxide (CO2), humidity, light and temperature sensors are c
 
 - Air quality sensors will be found if an entity has its unit of measurement set to `aqi` _or_ `homebridge_sensor_type` is set to `air_quality` on the entity.
 - Light sensors will be found if an entity has its unit of measurement set to `lux` _or_ `homebridge_sensor_type` is set to `light` on the entity.
-- Temperature sensors will be found if an entity has its unit of measurement set to `°C` or `°C`.
+- Temperature sensors will be found if an entity has its unit of measurement set to `°C`, `℃`, `°F`, or `℉`.
 - Humidity sensors will be found if an entity has its unit of measurement set to `%` and has an entity ID containing `humidity` _or_ `homebridge_sensor_type` is set to `humidity` on the entity.
 - Carbon Dioxide (CO2) sensors will be found if an entity has its unit of measurement set to `ppm` and has an entity ID containing `co2` _or_ `homebridge_sensor_type` is set to `co2` on the entity.
 

--- a/accessories/sensor.js
+++ b/accessories/sensor.js
@@ -150,13 +150,17 @@ function HomeAssistantSensorFactory(log, data, client) {
   let service;
   let characteristic;
   let transformData;
-  if (data.attributes.unit_of_measurement === '°C' || data.attributes.unit_of_measurement === '°F') {
+  if (data.attributes.unit_of_measurement === '°C'
+      || data.attributes.unit_of_measurement === '℃'
+      || data.attributes.unit_of_measurement === '°F'
+      || data.attributes.unit_of_measurement === '℉') {
     service = Service.TemperatureSensor;
     characteristic = Characteristic.CurrentTemperature;
     transformData = function transformData(dataToTransform) { // eslint-disable-line no-shadow
       let value = parseFloat(dataToTransform.state);
       // HomeKit only works with Celsius internally
-      if (dataToTransform.attributes.unit_of_measurement === '°F') {
+      if (dataToTransform.attributes.unit_of_measurement === '°F'
+          || dataToTransform.attributes.unit_of_measurement === '℉') {
         value = (value - 32) / 1.8;
       }
       return value;


### PR DESCRIPTION
Rather than a degree symbol (°) followed by a capital C or F, a single degree Celsius (℃) or degree Fahrenheit (℉) character can be used as a unit_of_measurement.