### PR TITLE
Added support for home assistant binary sensors: door and window

### DIFF
--- a/accessories/binary_sensor.js
+++ b/accessories/binary_sensor.js
@@ -192,6 +192,8 @@ function HomeAssistantBinarySensorFactory(log, data, client) {
         Characteristic.OccupancyDetected.OCCUPANCY_NOT_DETECTED
       );
     case 'opening':
+    case 'window':
+    case 'door':
       return new HomeAssistantBinarySensor(
         log, data, client,
         Service.ContactSensor,


### PR DESCRIPTION
I have couple binary sensor with device_class window or door. When I start home bridge, errors like this shows up in the log and these binary sensors are not being added to the accessories:

[2018-2-12 21:48:13] [HomeAssistant] 'binary_sensor.mqtt_living_room_window' has a device_class of 'window' which is not supported by homebridge-homeassistant. Supported classes are 'gas', 'moisture', 'motion', 'occupancy', 'opening' and 'smoke'. See the README.md for more information.
[2018-2-12 21:48:13] [HomeAssistant] 'binary_sensor.mqtt_kitchen_window' has a device_class of 'window' which is not supported by homebridge-homeassistant. Supported classes are 'gas', 'moisture', 'motion', 'occupancy', 'opening' and 'smoke'. See the README.md for more information.