### PR TITLE
Climate operation modes fix

### DIFF
--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -175,13 +175,8 @@ HomeAssistantClimate.prototype = {
     }
 
     // get list of supported operations and map our mode to supported one
-    let modes = this.data.operation_list;
-    var operation_mode = mode;
-    modes.forEach(element => {
-      if (element.toLowerCase() === mode) {
-        operation_mode = element;
-        break;
-      }
+    var operation_mode = this.data.operation_list.find(element => {
+      return element.toLocaleLowerCase() === mode;
     });
 
     serviceData.operation_mode = operation_mode;

--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -66,7 +66,7 @@ HomeAssistantClimate.prototype = {
       this.ThermostatService.getCharacteristic(Characteristic.TargetTemperature)
         .setValue(newState.attributes.temperature, null, 'internal');
       this.ThermostatService.getCharacteristic(Characteristic.TargetHeatingCoolingState)
-        .setValue(list[newState.state], null, 'internal');
+        .setValue(list[newState.state.toLowerCase()], null, 'internal');
     }
   },
   getCurrentTemp: function (callback) {
@@ -176,7 +176,7 @@ HomeAssistantClimate.prototype = {
 
     // get list of supported operations and map our mode to supported one
     var operation_mode = this.data.attributes.operation_list.find(element => {
-      return element.toLocaleLowerCase() === mode;
+      return element.toLowerCase() === mode;
     });
 
     serviceData.operation_mode = operation_mode;

--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -175,16 +175,14 @@ HomeAssistantClimate.prototype = {
     }
 
     // get list of supported operations and map our mode to supported one
-    var operation_mode = this.data.attributes.operation_list.find(element => {
-      return element.toLowerCase() === mode;
-    });
+    var operationMode = this.data.attributes.operation_list.find(element => element.toLowerCase() === mode);
 
-    serviceData.operation_mode = operation_mode;
-    this.log(`Setting Current Heating Cooling state on the '${this.name}' to ${operation_mode}`);
+    serviceData.operation_mode = operationMode;
+    this.log(`Setting Current Heating Cooling state on the '${this.name}' to ${operationMode}`);
 
     var that = this;
 
-    if (operation_mode === 'idle') {
+    if (operationMode === 'idle') {
       this.fanService.getCharacteristic(Characteristic.On)
         .setValue(false, null, 'internal');
     } else {

--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -175,7 +175,7 @@ HomeAssistantClimate.prototype = {
     }
 
     // get list of supported operations and map our mode to supported one
-    var operation_mode = this.data.operation_list.find(element => {
+    var operation_mode = this.data.attributes.operation_list.find(element => {
       return element.toLocaleLowerCase() === mode;
     });
 

--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -127,7 +127,7 @@ HomeAssistantClimate.prototype = {
     this.client.fetchState(this.entity_id, function (data) {
       if (data && data.attributes && data.attributes.operation_mode) {
         var state;
-        switch (data.attributes.operation_mode) {
+        switch (data.attributes.operation_mode.toLowerCase()) {
           case 'auto':
             state = Characteristic.TargetHeatingCoolingState.AUTO;
             break;
@@ -174,12 +174,22 @@ HomeAssistantClimate.prototype = {
         break;
     }
 
-    serviceData.operation_mode = mode;
-    this.log(`Setting Current Heating Cooling state on the '${this.name}' to ${mode}`);
+    // get list of supported operations and map our mode to supported one
+    let modes = this.data.operation_list;
+    var operation_mode = mode;
+    modes.forEach(element => {
+      if (element.toLowerCase() === mode) {
+        operation_mode = element;
+        break;
+      }
+    });
+
+    serviceData.operation_mode = operation_mode;
+    this.log(`Setting Current Heating Cooling state on the '${this.name}' to ${operation_mode}`);
 
     var that = this;
 
-    if (mode === 'idle') {
+    if (operation_mode === 'idle') {
       this.fanService.getCharacteristic(Characteristic.On)
         .setValue(false, null, 'internal');
     } else {

--- a/accessories/climate.js
+++ b/accessories/climate.js
@@ -175,7 +175,8 @@ HomeAssistantClimate.prototype = {
     }
 
     // get list of supported operations and map our mode to supported one
-    var operationMode = this.data.attributes.operation_list.find(element => element.toLowerCase() === mode);
+    var modes = this.data.attributes.operation_list;
+    var operationMode = modes.find(element => element.toLowerCase() === mode);
 
     serviceData.operation_mode = operationMode;
     this.log(`Setting Current Heating Cooling state on the '${this.name}' to ${operationMode}`);


### PR DESCRIPTION
Guys, 
I've noticed that zwave climate I use exposed to homebridge is not able to change operation mode as well as not reflects changes of operation mode from home assistant UI.

So climate.js logic assumes that names of states are lowercased as 'off', 'heat', 'cool', 'auto', while home assistant (v. 72, 74 for example) uses 'Off' and 'Heat' etc.

So this pull requests adds corresponding changes to make sure climate shown at homekit is able to change actual operation mode and reflects device changes correctly as well.

I'm not sure if 'Heat'/'Off' pattern is used always for any other types of thermostats, so I've tried to add changes not broking previous (lowercase always) way of mode naming.

Cheers )
